### PR TITLE
Fix train equipment stockpile entries in HRE industry focus

### DIFF
--- a/bakasekai/common/national_focus/hre_industry.txt
+++ b/bakasekai/common/national_focus/hre_industry.txt
@@ -90,10 +90,10 @@ shared_focus = {
 				instant_build = yes
 			}
 		}
-		add_equipment_to_stockpile = {
-			type = train_equipment
-			amount = 40
-		}
+               add_equipment_to_stockpile = {
+                       type = train_equipment_1
+                       amount = 40
+               }
 		add_equipment_to_stockpile = {
 			type = convoy
 			amount = 40
@@ -155,10 +155,10 @@ shared_focus = {
 				instant_build = yes
 			}
 		}
-		add_equipment_to_stockpile = {
-			type = train_equipment
-			amount = 50
-		}
+               add_equipment_to_stockpile = {
+                       type = train_equipment_1
+                       amount = 50
+               }
 		add_equipment_to_stockpile = {
 			type = convoy
 			amount = 60
@@ -235,10 +235,10 @@ shared_focus = {
 				instant_build = yes
 			}
 		}
-		add_equipment_to_stockpile = {
-			type = train_equipment
-			amount = 100
-		}
+               add_equipment_to_stockpile = {
+                       type = train_equipment_1
+                       amount = 100
+               }
 		add_equipment_to_stockpile = {
 			type = motorized_equipment_1
 			amount = 100


### PR DESCRIPTION
## Summary
- Ensure HRE industry focuses add specific train equipment variants to the stockpile

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ad554ec688322ba26ab6ea18ec72d