### PR TITLE
Fix ideology references in music

### DIFF
--- a/bakasekai/music/_songs.txt
+++ b/bakasekai/music/_songs.txt
@@ -55,7 +55,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = democratic
+			has_government = democratic_ideology
 		}		
 	}	
 }
@@ -68,7 +68,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = democratic
+			has_government = democratic_ideology
 		}		
 	}	
 }
@@ -81,7 +81,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -94,7 +94,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -133,7 +133,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -146,7 +146,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -159,7 +159,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -172,7 +172,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = fascism
+			has_government = fascism_ideology
 		}		
 	}	
 }
@@ -185,7 +185,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = democratic
+			has_government = democratic_ideology
 		}		
 	}	
 }
@@ -198,7 +198,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = democratic
+			has_government = democratic_ideology
 		}		
 	}	
 }
@@ -211,7 +211,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }
@@ -224,7 +224,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }
@@ -237,7 +237,7 @@ music = {
 			factor = 2
 
 			has_war = no
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }
@@ -251,7 +251,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }
@@ -264,7 +264,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }
@@ -277,7 +277,7 @@ music = {
 			factor = 2
 
 			has_war = yes
-			has_government = communism
+			has_government = communism_ideology
 		}		
 	}	
 }


### PR DESCRIPTION
## Summary
- fix music ideology checks to use mod-specific names

## Testing
- `pre-commit run --files bakasekai/music/_songs.txt` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_689b189765fc8322aa3496ed45255db4