### PR TITLE
Fix missing light tank variants for major powers

### DIFF
--- a/bakasekai/history/countries/RUS -Russia.txt
+++ b/bakasekai/history/countries/RUS -Russia.txt
@@ -63,16 +63,34 @@ if = {
 tank_tech_level_1 = yes
 
 if = {
-	limit = {
-		has_dlc = "No Step Back"
-	}
-	set_technology = {
-		gwtank_chassis = 1
-		basic_light_tank_chassis = 1
-		improved_light_tank_chassis = 1
-		engine_tech_1 = 1
-		engine_tech_2 = 1
-	}
+        limit = {
+                has_dlc = "No Step Back"
+        }
+        set_technology = {
+                gwtank_chassis = 1
+                basic_light_tank_chassis = 1
+                improved_light_tank_chassis = 1
+                engine_tech_1 = 1
+                engine_tech_2 = 1
+        }
+        create_equipment_variant = {
+                name = "BT-7"
+                type = light_tank_chassis_2
+                parent_version = 0
+                modules = {
+                        main_armament_slot = tank_auto_cannon
+                        turret_type_slot = tank_light_two_man_tank_turret
+                        suspension_type_slot = tank_christie_suspension
+                        armor_type_slot = tank_riveted_armor
+                        engine_type_slot = tank_gasoline_engine
+                        special_type_slot_1 = tank_radio_1
+                }
+                upgrades = {
+                        tank_nsb_engine_upgrade = 3
+                        tank_nsb_armor_upgrade = 2
+                }
+                icon = "GFX_SOV_improved_light_tank_medium"
+        }
 }
 
 if = {

--- a/bakasekai/history/units/FRA_1936.txt
+++ b/bakasekai/history/units/FRA_1936.txt
@@ -316,7 +316,7 @@ units = {
 		location = 11506
 		division_template = "Division Légère Mécanique" 	# DLM is frontline, best equipment, L Arm = H-35
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# IVe Corps d'Armée (Région Militaire in 1936) -- Le Mans
@@ -372,7 +372,7 @@ units = {
 		location = 11506
 		division_template = "Brigade de Chars de Combat" 		# R-35s
 		start_experience_factor = 0.2
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# Région Militaire de Paris -- Paris
@@ -413,7 +413,7 @@ units = {
 		division_template = "Brigade de Chars de Combat" 		# R-35s
 		start_experience_factor = 0.2
 		start_equipment_factor = 0.5
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# VIIe Corps d'Armée (Région Militaire in 1936) -- Besançon
@@ -969,15 +969,16 @@ instant_effect = {
 		efficiency = 50
 	}
 
-	add_equipment_production = {
-		equipment = {
-			type = light_tank_equipment_2
-			creator = "FRA" 
-		}
-		requested_factories = 1
-		progress = 0.4
-		efficiency = 50
-	}
+        add_equipment_production = {
+                equipment = {
+                        type = light_tank_chassis_1
+                        creator = "FRA"
+                        version_name = "H-35"
+                }
+                requested_factories = 1
+                progress = 0.4
+                efficiency = 50
+        }
 
 	add_equipment_production = {
 		equipment = {

--- a/bakasekai/history/units/FRA_1936_nsb.txt
+++ b/bakasekai/history/units/FRA_1936_nsb.txt
@@ -316,7 +316,7 @@ units = {
 		location = 11506
 		division_template = "Division Légère Mécanique" 	# DLM is frontline, best equipment, L Arm = H-35
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+           force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# IVe Corps d'Armée (Région Militaire in 1936) -- Le Mans
@@ -372,7 +372,7 @@ units = {
 		location = 11506
 		division_template = "Brigade de Chars de Combat" 		# R-35s
 		start_experience_factor = 0.2
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+           force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# Région Militaire de Paris -- Paris
@@ -413,7 +413,7 @@ units = {
 		division_template = "Brigade de Chars de Combat" 		# R-35s
 		start_experience_factor = 0.2
 		start_equipment_factor = 0.5
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "FRA" } }
+           force_equipment_variants = { light_tank_chassis_1 = { owner = "FRA" } }
 	}
 
 	# VIIe Corps d'Armée (Région Militaire in 1936) -- Besançon

--- a/bakasekai/history/units/GER_1936.txt
+++ b/bakasekai/history/units/GER_1936.txt
@@ -125,19 +125,19 @@ units = {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 	division= {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 	division= {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 
 	division= {
@@ -376,10 +376,11 @@ instant_effect = {
 	}
 
 	add_equipment_production = {
-		equipment = {
-			type = light_tank_equipment_1
-			creator = "DEU" 
-		}
+               equipment = {
+                       type = light_tank_chassis_1
+                       creator = "DEU"
+                       version_name = "Panzer I Ausf. A"
+               }
 		requested_factories = 2
 		progress = 0.4
 		efficiency = 50

--- a/bakasekai/history/units/GER_1936_nsb.txt
+++ b/bakasekai/history/units/GER_1936_nsb.txt
@@ -125,19 +125,19 @@ units = {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 	division= {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 	division= {
 		location = 6521
 		division_template = "Panzer-Division"
 		start_experience_factor = 0.3
-		force_equipment_variants = { light_tank_equipment_1 = { owner = "DEU" } }
+               force_equipment_variants = { light_tank_chassis_1 = { owner = "DEU" } }
 	}
 
 	division= {


### PR DESCRIPTION
## Summary
- use chassis-based tank variants in German and French 1936 unit setups
- define BT-7 light tank variant for Russia and update production lines

## Testing
- `echo "No tests specified" && ls bakasekai/tests >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_689b29c558088322a3eb583610fa68f9