### PR TITLE
Fix invalid HOI4 event syntax

### DIFF
--- a/bakasekai/events/_bsm_Fabricate_Claim_Events.txt
+++ b/bakasekai/events/_bsm_Fabricate_Claim_Events.txt
@@ -107,13 +107,11 @@ country_event = {
                 }
             }
         }
-        clear_event_target = bsm_target_state_for_claim_fabrication # 使用後クリア
     }
 
     option = {
         name = "BSM_FABRICATE_CLAIM_EVENT_1_OPT_B" # "中止する"
         ai_chance = { factor = 0 }
-        clear_event_target = bsm_target_state_for_claim_fabrication # 使用後クリア
     }
 }
 

--- a/bakasekai/events/emu_empire_events.txt
+++ b/bakasekai/events/emu_empire_events.txt
@@ -14,10 +14,7 @@ country_event = {
 		name = emu_empire.1.a
 		add_political_power = 100
 		add_stability = 0.1
-		add_modifier = {
-			name = emu_empire_awakened
-			duration = -1
-		}
+                add_ideas = emu_empire_awakened
 		ai_chance = { factor = 100 }
 	}
 }
@@ -31,7 +28,7 @@ country_event = {
 	
 	trigger = {
 		tag = AUS
-		has_modifier = emu_war_legacy
+                has_idea = emu_war_legacy
 		date > 1936.11.1
 		date < 1936.11.30
 	}
@@ -63,10 +60,7 @@ country_event = {
 	option = {
 		name = emu_empire.3.a
 		add_political_power = 200
-		add_modifier = {
-			name = feathered_bureaucracy
-			duration = -1
-		}
+                add_ideas = feathered_bureaucracy
 		ai_chance = { factor = 100 }
 	}
 }
@@ -80,12 +74,12 @@ country_event = {
 	
 	trigger = {
 		tag = AUS
-		has_modifier = dust_storm_defense
+                has_idea = dust_storm_defense
 		has_war = yes
 		any_enemy_country = {
 			any_owned_state = {
-				is_coastal = no
-				is_terrain = desert
+                                is_coastal = no
+                                has_terrain = desert
 			}
 		}
 	}
@@ -96,10 +90,10 @@ country_event = {
 	
 	option = {
 		name = emu_empire.4.a
-		add_modifier = {
-			name = dust_storm_advantage
-			duration = 60
-		}
+                add_dynamic_modifier = {
+                        modifier = dust_storm_advantage
+                        days = 60
+                }
 		ai_chance = { factor = 100 }
 	}
 }
@@ -166,10 +160,7 @@ country_event = {
 	option = {
 		name = emu_empire.6.a
 		add_political_power = 300
-		add_modifier = {
-			name = emu_world_ambition
-			duration = -1
-		}
+                add_ideas = emu_world_ambition
 		every_other_country = {
 			limit = { is_major = yes }
 			country_event = { id = emu_empire.7 days = 1 }
@@ -224,10 +215,7 @@ country_event = {
 	
 	option = {
 		name = emu_empire.8.a
-		add_modifier = {
-			name = emu_migration_bonus
-			duration = -1
-		}
+                add_ideas = emu_migration_bonus
 		random_owned_controlled_state = {
 			limit = { is_coastal = no }
 			add_building_construction = {
@@ -289,7 +277,7 @@ country_event = {
 	
 	trigger = {
 		tag = AUS
-		has_modifier = emu_ramming_tactics
+                has_idea = emu_ramming_tactics
 		has_war = yes
 		any_enemy_country = {
 			has_tech = basic_light_tank_chassis
@@ -302,10 +290,10 @@ country_event = {
 	
 	option = {
 		name = emu_empire.10.a
-		add_modifier = {
-			name = successful_ramming_operation
-			duration = 120
-		}
+                add_dynamic_modifier = {
+                        modifier = successful_ramming_operation
+                        days = 120
+                }
 		add_war_support = 0.10
 		ai_chance = { factor = 100 }
 	}
@@ -353,10 +341,10 @@ country_event = {
 	
 	option = {
 		name = emu_empire.11.b
-		add_modifier = {
-			name = avian_diplomatic_isolationism
-			duration = 365
-		}
+                add_dynamic_modifier = {
+                        modifier = avian_diplomatic_isolationism
+                        days = 365
+                }
 		ai_chance = { factor = 20 }
 	}
 }
@@ -377,10 +365,7 @@ country_event = {
 	
 	option = {
 		name = emu_empire.12.a
-		add_modifier = {
-			name = wingless_conqueror_spirit
-			duration = -1
-		}
+                add_ideas = wingless_conqueror_spirit
 		add_named_threat = { threat = 5 name = "Emu Empire Expansionism" }
 		every_other_country = {
 			limit = { is_major = yes }


### PR DESCRIPTION
## Summary
- remove unsupported clear_event_target call in fabricate claim event
- replace obsolete add_modifier/has_modifier/is_terrain commands in Emu Empire events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c4d71b7008322b538416cb552dc3d