### PR TITLE
Fix scientist portraits file structure

### DIFF
--- a/bakasekai/portraits/998_scientist_portraits.txt
+++ b/bakasekai/portraits/998_scientist_portraits.txt
@@ -201,16 +201,17 @@ continent = {
 			"GFX_portrait_generic_europe_female_12"
 			"GFX_portrait_generic_europe_female_14"
 		}
-		male = {
-			"GFX_portrait_generic_australia_male_01"
-			"GFX_portrait_generic_australia_male_02"
-			"GFX_portrait_generic_australia_male_03"
-			"GFX_portrait_generic_europe_male_02"
-			"GFX_portrait_generic_europe_male_04"
-			"GFX_portrait_generic_europe_male_06"
-			"GFX_portrait_generic_europe_male_10"
-			"GFX_portrait_generic_europe_male_14"
-			"GFX_portrait_generic_europe_male_15"
+                male = {
+                        "GFX_portrait_generic_australia_male_01"
+                        "GFX_portrait_generic_australia_male_02"
+                        "GFX_portrait_generic_australia_male_03"
+                        "GFX_portrait_generic_europe_male_02"
+                        "GFX_portrait_generic_europe_male_04"
+                        "GFX_portrait_generic_europe_male_06"
+                        "GFX_portrait_generic_europe_male_10"
+                        "GFX_portrait_generic_europe_male_14"
+                        "GFX_portrait_generic_europe_male_15"
+                }
         }
 }
 
@@ -322,7 +323,6 @@ continent = {
                         "GFX_portrait_generic_asia_male_08"
                 }
         }
-}
 }
 
 PAK = {


### PR DESCRIPTION
## Summary
- close missing braces in scientist portraits for Australia
- remove stray brace after Shikoku portraits

## Testing
- `python - <<'PY'
import sys, re, pathlib
path=pathlib.Path('bakasekai/portraits/998_scientist_portraits.txt')
text=path.read_text(encoding='utf-8')
open_count=text.count('{')
close_count=text.count('}')
print('open',open_count,'close',close_count)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689c5d55e6e88322b1ece3049c24339c