### PR TITLE
Fix London event tokens and ideology trigger

### DIFF
--- a/bakasekai/common/opinion_modifiers/LON_opinion_modifiers.txt
+++ b/bakasekai/common/opinion_modifiers/LON_opinion_modifiers.txt
@@ -40,4 +40,26 @@ opinion_modifiers = {
         value = -30
         decay = 2
     }
+
+    # アイルランド交渉関連
+    LON_irish_displeasure = {
+        value = -20
+        decay = 1
+    }
+
+    LON_irish_friendship = {
+        value = 20
+        decay = 1
+        trade = yes
+    }
+
+    LON_irish_animosity = {
+        value = -40
+        decay = 1
+    }
+
+    LON_dominion_rejected = {
+        value = -25
+        decay = 1
+    }
 }

--- a/bakasekai/events/LON_events.txt
+++ b/bakasekai/events/LON_events.txt
@@ -173,7 +173,7 @@ news_event = {
 
 # アイルランド原住民との交渉開始イベント
 country_event = {
-    id = LON_ireland_negotiation_start
+    id = LON.ireland_negotiation_start
     title = LON.ireland_negotiation_start.t
     desc = LON.ireland_negotiation_start.desc
     picture = GFX_report_event_ireland_generic_1 # 適当な汎用画像
@@ -185,7 +185,7 @@ country_event = {
         ai_chance = { factor = 80 }
         set_country_flag = LON_ireland_negotiations_ongoing # 交渉中フラグ
         add_political_power = -50
-        country_event = { id = LON_ireland_negotiation_progress days = 60 random_days = 30 }
+        country_event = { id = LON.ireland_negotiation_progress days = 60 random_days = 30 }
     }
     option = {
         name = LON.ireland_negotiation_start.b # 交渉を拒否# [cite: 12]
@@ -198,7 +198,7 @@ country_event = {
 
 # アイルランド交渉進捗イベント
 country_event = {
-    id = LON_ireland_negotiation_progress
+    id = LON.ireland_negotiation_progress
     title = LON.ireland_negotiation_progress.t
     desc = LON.ireland_negotiation_progress.desc
     picture = GFX_report_event_ireland_generic_2 # 適当な汎用画像
@@ -229,7 +229,7 @@ country_event = {
 
 # ドミニオン地位獲得イベント
 country_event = {
-    id = LON_seek_dominion_status
+    id = LON.seek_dominion_status
     title = LON.seek_dominion_status.t
     desc = LON.seek_dominion_status.desc
     picture = GFX_report_event_dominion # 適当な画像
@@ -274,9 +274,9 @@ country_event = {
 
 # 独立時のロンドン橋破壊イベント
 country_event = {
-    id = LON_london_bridge_destroyed_on_independence
-    title = LON.london_bridge_destroyed_on_independence.t
-    desc = LON.london_bridge_destroyed_on_independence.desc
+    id = LON.london_bridge_destroyed_on_independence
+    title = LON_london_bridge_destroyed_on_independence.t
+    desc = LON_london_bridge_destroyed_on_independence.desc
     picture = GFX_report_event_london_bridge_destroyed # ロンドン橋破壊の画像
     
     is_triggered_only = yes
@@ -296,9 +296,9 @@ country_event = {
 
 # ロンドン橋の定期的な損耗イベント
 country_event = {
-    id = LON_london_bridge_wear_and_tear
-    title = LON.london_bridge_wear_and_tear.t
-    desc = LON.london_bridge_wear_and_tear.desc
+    id = LON.london_bridge_wear_and_tear
+    title = LON_london_bridge_wear_and_tear.t
+    desc = LON_london_bridge_wear_and_tear.desc
     picture = GFX_report_event_bridge_damage # 橋の損傷の画像
     
     # is_triggered_only を削除するか no に設定しないと mean_time_to_happen は機能しません。
@@ -334,7 +334,7 @@ country_event = {
         # 損耗度が一定値を超えたら警告イベント
         if = {
             limit = { check_variable = { var = LON_london_bridge_condition compare = greater_than value = 70 } }# [cite: 24]
-            country_event = { id = LON_london_bridge_critical_condition hours = 1 }
+            country_event = { id = LON.london_bridge_critical_condition hours = 1 }
         }
     }
 
@@ -345,9 +345,9 @@ country_event = {
 
 # ロンドン橋が深刻な損耗状態になった警告イベント
 country_event = {
-    id = LON_london_bridge_critical_condition
-    title = LON.london_bridge_critical_condition.t
-    desc = LON.london_bridge_critical_condition.desc
+    id = LON.london_bridge_critical_condition
+    title = LON_london_bridge_critical_condition.t
+    desc = LON_london_bridge_critical_condition.desc
     picture = GFX_report_event_bridge_critical # 橋が危険な状態の画像
     
     is_triggered_only = yes # mean_time_to_happen がないため is_triggered_only を維持
@@ -374,9 +374,9 @@ country_event = {
 # バトル中央銀行危機 (Battle Central Bank Crisis) イベント群
 # ============================================================================
 country_event = {
-    id = LON_battle_central_bank_crisis_start
-    title = LON.battle_central_bank_crisis.start.t
-    desc = LON.battle_central_bank_crisis.start.desc
+    id = LON.battle_central_bank_crisis_start
+    title = LON_battle_central_bank_crisis_start.t
+    desc = LON_battle_central_bank_crisis_start.desc
     picture = GFX_report_event_economic_crisis # 経済危機を示す汎用画像# [cite: 27]
     
     is_triggered_only = yes # グローバルフラッグでトリガーされる

--- a/bakasekai/events/LON_investment_events.txt
+++ b/bakasekai/events/LON_investment_events.txt
@@ -52,8 +52,8 @@ country_event = {
             factor = 15
             modifier = {
                 factor = 0.3
-                has_government = democratic
-                democratic > 0.7
+                has_government = democratic_ideology
+                democratic_ideology > 0.7
             }
         }
         FROM = {

--- a/bakasekai/localisation/english/bakasekai/lon_I_english.yml
+++ b/bakasekai/localisation/english/bakasekai/lon_I_english.yml
@@ -87,6 +87,10 @@ EV_OK: "Understood."
 
  # Opinion Modifiers
  great_economic_ties: "Strong Economic Ties"
+ LON_irish_displeasure: "Irish Displeasure"
+ LON_irish_friendship: "Irish Friendship"
+ LON_irish_animosity: "Irish Animosity"
+ LON_dominion_rejected: "Dominion Request Rejected"
 
 
  # Decisions (Battle Central Bank Crisis)

--- a/bakasekai/localisation/japanese/bakasekai/lon_I_japanese.yml
+++ b/bakasekai/localisation/japanese/bakasekai/lon_I_japanese.yml
@@ -87,6 +87,10 @@ EV_OK: "わかった。"
 
  # Opinion Modifiers
  great_economic_ties: "強固な経済的つながり"
+ LON_irish_displeasure: "アイルランドの不満"
+ LON_irish_friendship: "アイルランドとの友好"
+ LON_irish_animosity: "アイルランドへの敵意"
+ LON_dominion_rejected: "自治領要請の拒否"
 
 
  # Decisions (Battle Central Bank Crisis)


### PR DESCRIPTION
## Summary
- fix malformed London event IDs and references
- add missing opinion modifiers and localization
- replace deprecated democratic trigger with democratic_ideology

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c692f582083228d441bd68262f38a