### PR TITLE
Fix invalid modifier in MYS events

### DIFF
--- a/bakasekai/common/dynamic_modifiers/bsm_dynamic_modifiers.txt
+++ b/bakasekai/common/dynamic_modifiers/bsm_dynamic_modifiers.txt
@@ -21,6 +21,16 @@ bsm_dropped_nuke_modifier = {#核の落ちた町
 }
 
 bsm_uc_factor = {
-	enable = { always = yes }
-	Unified_Currency_gain_factor = combined_uc_factor
+        enable = { always = yes }
+        Unified_Currency_gain_factor = combined_uc_factor
+}
+
+mys_expedition_penalty_1 = {
+       enable = { always = yes }
+       base_Cultural_Degree = -0.55
+}
+
+mys_expedition_penalty_2 = {
+       enable = { always = yes }
+       base_Cultural_Degree = -0.50
 }

--- a/bakasekai/events/MYS.txt
+++ b/bakasekai/events/MYS.txt
@@ -18,12 +18,12 @@ country_event = {
 		}
 		add_manpower = -5
 
-		hidden_effect = {
-			modifier = {
-				base_Cultural_Degree = -0.55
-			}
-		}
-	}
+               hidden_effect = {
+                       add_dynamic_modifier = {
+                               modifier = mys_expedition_penalty_1
+                       }
+               }
+       }
 }
 country_event = {
 	id = MYS.2	#調査隊の帰還
@@ -41,10 +41,10 @@ country_event = {
 		ai_chance = {
 			factor = 100
 		}
-		hidden_effect = {
-			modifier = {
-				base_Cultural_Degree = -0.50
-			}
-		}
-	}
+               hidden_effect = {
+                       add_dynamic_modifier = {
+                               modifier = mys_expedition_penalty_2
+                       }
+               }
+       }
 }


### PR DESCRIPTION
## Summary
- add dynamic modifiers to reduce base cultural degree
- apply new dynamic modifiers in MYS events instead of invalid `modifier` effect

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689c693e8960832290196870830eb0e4