### PR TITLE
Fix Nokia event script errors

### DIFF
--- a/bakasekai/events/NOK_ev.txt
+++ b/bakasekai/events/NOK_ev.txt
@@ -182,7 +182,7 @@ country_event = {
     option = {
         name = nokia.40.a
         add_stability = 0.05
-        add_research_bonus = {
+        add_tech_bonus = {
             bonus = 0.5
             uses = 1
             category = industry
@@ -206,7 +206,7 @@ country_event = {
     
     option = {
         name = nokia.100.a  # "Sponsor the championship!"
-        trigger = { political_power > 25 }
+        trigger = { has_political_power > 25 }
         add_political_power = -25
         add_stability = 0.02
         add_war_support = 0.01
@@ -218,16 +218,3 @@ country_event = {
     }
 }
 
-# Legacy Event (compatibility)
-news_event = {
-    id = NOK.1
-    title = NOK.1.t
-    desc = NOK.1.d
-    picture = GFX_news_event_001
-    
-    is_triggered_only = yes
-    
-    option = {
-        name = NOK.1.a
-    }
-}


### PR DESCRIPTION
## Summary
- use `add_tech_bonus` instead of invalid `add_research_bonus`
- require `has_political_power` trigger for Snake Championship option
- remove obsolete `NOK.1` legacy event block causing malformed token

## Testing
- `cd bakasekai && make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689c69501a4c8322b9b9cd2c5f148413