### PR TITLE
Fix invalid focus triggers and building references

### DIFF
--- a/bakasekai/common/continuous_focus/generic.txt
+++ b/bakasekai/common/continuous_focus/generic.txt
@@ -23,11 +23,7 @@ continuous_focus_palette = {
 			}
 		}
 
-		enable = {
-			has_power_balance = {
-				id = DEN_occupation_balance
-			}
-		}
+                # removed enable block referencing undefined balance of power
 
 		modifier = {
 			power_balance_weekly = 0.01
@@ -40,21 +36,7 @@ continuous_focus_palette = {
 				# has_completed_focus = DEN_escalate_the_sabotages
 				# has_completed_focus = DEN_expand_the_resistance
 			}
-			modifier = {
-				factor = 10
-				power_balance_value = {
-					id = DEN_occupation_balance
-					value < 0.9
-				}
-			}
-			modifier = {
-				factor = 0	
-				# has_completed_focus = DEN_declare_independence
-				power_balance_value = {
-					id = DEN_occupation_balance
-					value > 0.9
-				}
-			}
+                        # removed power balance modifiers due to missing balance definition
 		}
 		
 		supports_ai_strategy = ai_focus_defense

--- a/bakasekai/common/national_focus/BSM_share_generic.txt
+++ b/bakasekai/common/national_focus/BSM_share_generic.txt
@@ -14,9 +14,9 @@
 			focus = HRE_focus_to_nuke
 		}
 		available_if_capitulated = yes
-		available = {
-			has_completed_focus = HRE_focus_of_nuke
-		}
+                available = {
+                        has_completed_focus = HRE_focus_to_nuke
+                }
 		completion_reward = {
 			army_experience = 100
 			add_doctrine_cost_reduction = {

--- a/bakasekai/common/national_focus/generic2.txt
+++ b/bakasekai/common/national_focus/generic2.txt
@@ -251,23 +251,23 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
-					free_building_slots = {
-						building = civilian_factory
+                                            free_building_slots = {
+                                                building = industrial_complex
 						size = 1
 					}
 				}
-				add_building_construction = { type = civilian_factory level = 2 instant_build = yes }
+                                add_building_construction = { type = industrial_complex level = 2 instant_build = yes }
 			}
 			if = {
 				limit = { has_government = civilism }
 				random_owned_controlled_state = {
 					limit = {
-						free_building_slots = {
-							building = civilian_factory
+                                                    free_building_slots = {
+                                                        building = industrial_complex
 							size = 1
 						}
 					}
-					add_building_construction = { type = civilian_factory level = 1 instant_build = yes }
+                                            add_building_construction = { type = industrial_complex level = 1 instant_build = yes }
 				}
 			}
 			if = { limit = { has_government = technicalism } add_research_slot = 1 }
@@ -287,12 +287,12 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
-					free_building_slots = {
-						building = civilian_factory
+                                            free_building_slots = {
+                                                building = industrial_complex
 						size = 1
 					}
 				}
-				add_building_construction = { type = civilian_factory level = 3 instant_build = yes }
+                                add_building_construction = { type = industrial_complex level = 3 instant_build = yes }
 			}
 			if = { limit = { has_government = futurism } add_tech_bonus = { name = industrial_bonus bonus = 1 uses = 2 category = industry } }
 		}
@@ -425,12 +425,12 @@ focus_tree = {
 				limit = { has_government = civilism }
 				random_owned_controlled_state = {
 					limit = {
-						free_building_slots = {
-							building = civilian_factory
+                                                    free_building_slots = {
+                                                        building = industrial_complex
 							size = 1
 						}
 					}
-					add_building_construction = { type = civilian_factory level = 1 instant_build = yes }
+                                            add_building_construction = { type = industrial_complex level = 1 instant_build = yes }
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- correct typo in `BSM_share_generic` focus requirement
- replace deprecated `civilian_factory` building IDs with `industrial_complex`
- remove undefined power balance triggers from continuous focuses

## Testing
- `rg -n "civilian_factory" bakasekai/common/national_focus/generic2.txt`
- `rg -n "has_power_balance" bakasekai/common/continuous_focus/generic.txt`
- `rg -n "power_balance_value" bakasekai/common/continuous_focus/generic.txt`


------
https://chatgpt.com/codex/tasks/task_e_689c69a1b5348322b7ef667f5642a102