### PR TITLE
Add hexadecimal system character names

### DIFF
--- a/bakasekai/common/names/SYSTEM_names.txt
+++ b/bakasekai/common/names/SYSTEM_names.txt
@@ -1,9 +1,9 @@
 _ = {
-        male = {
-                names = { "System" }
-        }
-        female = {
-                names = { "System" }
-        }
-        surnames = { "Manager" }
+    male = {
+        names = { "System" "00" "01" "02" "03" "04" "05" "06" "07" "08" "09" "0A" "0B" "0C" "0D" "0E" "0F" }
+    }
+    female = {
+        names = { "System" "00" "01" "02" "03" "04" "05" "06" "07" "08" "09" "0A" "0B" "0C" "0D" "0E" "0F" }
+    }
+    surnames = { "Manager" "00" "01" "02" "03" "04" "05" "06" "07" "08" "09" "0A" "0B" "0C" "0D" "0E" "0F" }
 }


### PR DESCRIPTION
## Summary
- expand system male, female and surname lists with hexadecimal-style entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c8cf1c72c8322bb428732192768c2