### PR TITLE
Fix invalid relative_position_id references

### DIFF
--- a/bakasekai/common/national_focus/BSM_share_generic.txt
+++ b/bakasekai/common/national_focus/BSM_share_generic.txt
@@ -3,9 +3,8 @@
 	shared_focus = {
 		id = sf_army_effort
 		icon = GFX_goal_generic_allies_build_infantry
-		relative_position_id = HRE_focus_to_doctrine_2
-		x = 0
-		y = 4
+                x = 0
+                y = 4
 		cost = 10
 		search_filters = {
 			FOCUS_FILTER_RESEARCH
@@ -282,9 +281,8 @@
 	shared_focus = {
 		id = sf_aviation_effort
 		icon = GFX_goal_generic_build_airforce
-		relative_position_id = HRE_focus_to_doctrine_2
-		x = -4
-		y = 4
+                x = -4
+                y = 4
 		cost = 10
 		search_filters = {
 			FOCUS_FILTER_RESEARCH
@@ -627,9 +625,8 @@
 	shared_focus = {
 		id = sf_naval_effort
 		icon = GFX_goal_generic_construct_naval_dockyard
-		relative_position_id = HRE_focus_to_doctrine_2
-		x = 4
-		y = 4
+                x = 4
+                y = 4
 		cost = 10
 		search_filters = {
 			FOCUS_FILTER_INDUSTRY
@@ -1033,10 +1030,9 @@
 	shared_focus = {
 		id = sf_industrial_effort
 		icon = GFX_goal_generic_production
-			relative_position_id = HRE_research_slot_2
-		x = 0
-		y = 7
-		cost = 10
+                x = 0
+                y = 7
+                cost = 10
 		search_filters = {
 			FOCUS_FILTER_INDUSTRY
 			FOCUS_FILTER_RESEARCH


### PR DESCRIPTION
## Summary
- remove references to undefined focus IDs in shared generic focus tree

## Testing
- `rg -n --stats "HRE_research_slot_2" bakasekai/common/national_focus/BSM_share_generic.txt`
- `rg -n --stats "HRE_focus_to_doctrine_2" bakasekai/common/national_focus/BSM_share_generic.txt`


------
https://chatgpt.com/codex/tasks/task_e_689c8db03bb48322836e1e1eca536591