### PR TITLE
Use bsm_24h font on loading screen

### DIFF
--- a/bakasekai/interface/replace/load_screen.gui
+++ b/bakasekai/interface/replace/load_screen.gui
@@ -49,7 +49,7 @@ guiTypes = {
 				name = "text"
 				position = { x = -400 y = 13 }
 				textureFile = ""
-				font = "loadscreen_header"
+                               font = "bsm_24h"
 				borderSize = {x = 0 y = 0}
 				text = ""	
 				maxWidth = 800
@@ -89,7 +89,7 @@ guiTypes = {
 				name = "text"
 				position = { x = -450 y = -157 }
 				textureFile = ""
-				font = "loadscreen_tip"
+                               font = "bsm_24h"
 				borderSize = {x = 0 y = 0}
 				text = ""	
 				maxWidth = 900


### PR DESCRIPTION
## Summary
- switch loading screen text to use `bsm_24h` font

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9108331c83228f1c8f19572ca502