### PR TITLE
fix: mark coastal provinces

### DIFF
--- a/bakasekai/map/definition.csv
+++ b/bakasekai/map/definition.csv
@@ -2898,7 +2898,7 @@
 2897;38;4;240;sea;false;ocean;0
 2898;38;8;236;sea;true;ocean;0
 2899;38;10;244;sea;true;ocean;0
-2900;38;12;232;land;false;forest;6
+2900;38;12;232;land;true;forest;6
 2901;38;16;248;sea;true;ocean;0
 2902;38;17;236;sea;false;ocean;0
 2903;38;18;244;sea;true;ocean;0
@@ -2921,7 +2921,7 @@
 2920;39;4;244;sea;false;ocean;0
 2921;39;8;240;sea;true;ocean;0
 2922;39;10;248;sea;true;ocean;0
-2923;39;12;236;land;false;hills;6
+2923;39;12;236;land;true;hills;6
 2924;39;14;244;sea;true;ocean;0
 2925;39;16;232;sea;false;ocean;0
 2926;39;17;240;sea;false;ocean;0
@@ -14133,7 +14133,7 @@
 14132;195;244;245;land;false;forest;6
 14133;196;244;245;land;false;forest;6
 14134;197;244;245;land;false;forest;6
-14135;198;244;245;land;false;forest;6
+14135;198;244;245;land;true;forest;6
 14136;199;244;245;land;false;forest;6
 14137;200;244;245;land;false;forest;6
 14138;201;244;244;land;false;desert;8


### PR DESCRIPTION
## Summary
- ensure provinces 2900, 2923, and 14135 are flagged as coastal to match map bitmap

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689c9611c1c08322bfed012c66ef60ec