### PR TITLE
fix: remove Ireland requirement from London focus

### DIFF
--- a/bakasekai/common/national_focus/uk.txt
+++ b/bakasekai/common/national_focus/uk.txt
@@ -11418,7 +11418,6 @@ focus_tree = {
 		}
 		available = {
 			is_subject = no
-			country_exists = IRE
 			NOT = {
 				is_in_faction_with = IRE
 			}


### PR DESCRIPTION
## Summary
- allow London's 'Consolidate the British Isles' focus without Ireland existing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9854654c8322be7280c4d9a7c46e