### PR TITLE
Enable penguin troops for poles

### DIFF
--- a/bakasekai/history/countries/NPL - North Pole.txt
+++ b/bakasekai/history/countries/NPL - North Pole.txt
@@ -1,5 +1,5 @@
 capital = 1000
-oob = "Default_oob"
+oob = "pengin"
 set_research_slots = 10
 set_technology = {
 	tech_support = 1
@@ -8,9 +8,10 @@ set_technology = {
 	early_fighter = 1
 	gwtank = 1
 	basic_light_tank = 1
-	infantry_weapons = 1
-	infantry_weapons1 = 1
-	fuel_silos = 1
+        infantry_weapons = 1
+        infantry_weapons1 = 1
+        fuel_silos = 1
+        army_of_penguin = 1
 }
 
 set_convoys = 0

--- a/bakasekai/history/countries/SPL - South pol.txt
+++ b/bakasekai/history/countries/SPL - South pol.txt
@@ -1,5 +1,5 @@
 capital = 919
-oob = "Default_oob"
+oob = "pengin"
 set_research_slots = 4
 add_ideas = {
 	high_speed_dream
@@ -24,9 +24,10 @@ set_technology = {
 	fighter1 = 1
 	early_bomber = 1
 	strategic_bomber1 = 1
-	naval_bomber1 = 1
-	mass_assault = 1
-	fleet_in_being = 1
+        naval_bomber1 = 1
+        mass_assault = 1
+        fleet_in_being = 1
+        army_of_penguin = 1
 }
 
 if = {


### PR DESCRIPTION
## Summary
- Allow South Pole and North Pole to start with penguin troop tech and templates

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c9971688483229ef5949b25850217