### PR TITLE
Fix Nokia tech bonus and add stub decisions

### DIFF
--- a/bakasekai/common/decisions/NKA_decisions.txt
+++ b/bakasekai/common/decisions/NKA_decisions.txt
@@ -1,0 +1,39 @@
+emu_expansion_decisions = {
+    NKA_network_expansion_decisions = {
+        icon = GFX_decision_generic_construct_civilian
+        allowed = {
+            original_tag = NKA
+            always = yes
+        }
+        visible = {
+            always = yes
+        }
+        available = {
+            always = yes
+        }
+        cost = 10
+        complete_effect = {
+            add_political_power = -10
+        }
+    }
+}
+
+emu_bird_diplomacy = {
+    NKA_patent_war_decisions = {
+        icon = GFX_decision_generic_diplomacy
+        allowed = {
+            original_tag = NKA
+            always = yes
+        }
+        visible = {
+            always = yes
+        }
+        available = {
+            always = yes
+        }
+        cost = 10
+        complete_effect = {
+            add_political_power = -10
+        }
+    }
+}

--- a/bakasekai/common/decisions/categories/NKA_decision_categories.txt
+++ b/bakasekai/common/decisions/categories/NKA_decision_categories.txt
@@ -1,0 +1,21 @@
+emu_expansion_decisions = {
+    icon = GFX_decision_category_generic_political
+    allowed = {
+        original_tag = NKA
+        always = yes
+    }
+    visible = {
+        always = yes
+    }
+}
+
+emu_bird_diplomacy = {
+    icon = GFX_decision_category_generic_diplomacy
+    allowed = {
+        original_tag = NKA
+        always = yes
+    }
+    visible = {
+        always = yes
+    }
+}

--- a/bakasekai/common/national_focus/NOKIA.txt
+++ b/bakasekai/common/national_focus/NOKIA.txt
@@ -124,17 +124,22 @@ focus_tree = {
 		y = 1
 
 	}
-	focus = {
-		id = NOK_army
-		icon = GFX_goal_unknown
-		cost = 10.00
-		prerequisite = {
-			focus = NOK_guntoushi
-		}
-		x = 11
-		y = 4
-
-	}
+        focus = {
+                id = NOK_army
+                icon = GFX_goal_unknown
+                cost = 10.00
+                prerequisite = {
+                        focus = NOK_guntoushi
+                }
+                x = 11
+                y = 4
+                completion_reward = {
+                        add_tech_bonus = {
+                                bonus = 0.5
+                                category = cat_mobile_warfare
+                        }
+                }
+        }
 	focus = {
 		id = NOK_sinwa
 		icon = GFX_goal_unknown


### PR DESCRIPTION
## Summary
- correct Nokia army focus tech bonus to use `cat_mobile_warfare`
- define missing decision categories for NKA
- add placeholder decisions for network expansion and patent war

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c982b10088322a5717f68105b6ab9