### PR TITLE
Spawn units for Chinese civil war breakaways

### DIFF
--- a/bakasekai/common/scripted_effects/CHN_civil_war_effects.txt
+++ b/bakasekai/common/scripted_effects/CHN_civil_war_effects.txt
@@ -1,0 +1,22 @@
+CHN_civil_war_spawn_units_effect = {
+	every_owned_state = {
+		random_list = {
+		    25 = { create_unit = { division = "name = \"Militia Division\" division_template = \"Militia\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Artillery Division\" division_template = \"Artillery Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Cavalry Division\" division_template = \"Cavalry Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Infantry Division\" division_template = \"Infantry Division\" start_experience_factor = 0.3" owner = PREV } }
+		}
+		random_list = {
+		    25 = { create_unit = { division = "name = \"Militia Division\" division_template = \"Militia\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Artillery Division\" division_template = \"Artillery Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Cavalry Division\" division_template = \"Cavalry Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Infantry Division\" division_template = \"Infantry Division\" start_experience_factor = 0.3" owner = PREV } }
+		}
+		random_list = {
+		    25 = { create_unit = { division = "name = \"Militia Division\" division_template = \"Militia\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Artillery Division\" division_template = \"Artillery Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Cavalry Division\" division_template = \"Cavalry Division\" start_experience_factor = 0.3" owner = PREV } }
+		    25 = { create_unit = { division = "name = \"Infantry Division\" division_template = \"Infantry Division\" start_experience_factor = 0.3" owner = PREV } }
+		}
+	}
+}

--- a/bakasekai/events/CHN_civil_war.txt
+++ b/bakasekai/events/CHN_civil_war.txt
@@ -35,7 +35,6 @@ country_event = {
 					target = RAJ
 					type = puppet_wargoal_focus
 				}
-			}
 			RAJ = {
 				add_political_power = 100
 				set_state_controller = 619
@@ -283,6 +282,7 @@ country_event = {
 					target = RAJ
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 			JAP = {
 				country_event = {
@@ -359,6 +359,7 @@ country_event = {
 					target = ENG
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 			CHN = {
 				country_event = {
@@ -436,6 +437,7 @@ country_event = {
 					target = PRC
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 		}
 	}
@@ -522,6 +524,7 @@ country_event = {
 					target = SHX
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 			CHN = {
 				country_event = {
@@ -590,6 +593,7 @@ country_event = {
 					target = CHN
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 				promote_character = {
 					character = MAN_aisin_gioro_puyi
 					ideology = constitutional_emperor
@@ -696,6 +700,7 @@ country_event = {
 					target = MME
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 			CHN = {
 				country_event = {
@@ -794,6 +799,7 @@ country_event = {
 					target = MME
 					type = puppet_wargoal_focus
 				}
+				CHN_civil_war_spawn_units_effect = yes
 			}
 			CHN = {
 				country_event = {


### PR DESCRIPTION
## Summary
- Add scripted effect spawning random militia, artillery, cavalry and infantry divisions per owned state
- Trigger this spawn for Chinese civil war breakaway countries when they declare independence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c99d0917483229dc2ed5923ae330e