### PR TITLE
Fix missing LON namespace for London events

### DIFF
--- a/bakasekai/events/LON_events.txt
+++ b/bakasekai/events/LON_events.txt
@@ -1,4 +1,5 @@
 add_namespace = LON.leader_change
+add_namespace = LON
 
 news_event = {
     id = LON.leader_change.1


### PR DESCRIPTION
## Summary
- define `add_namespace = LON` in `LON_events.txt` to register event IDs

## Testing
- `rg "id = LON" -n bakasekai/events/LON_events.txt | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689d8afdc88c8322b918b3a346116a11