### PR TITLE
Fix scripted diplomatic action definition

### DIFF
--- a/bakasekai/common/scripted_diplomatic_actions/BSM_custom_diplomatic_actions.txt
+++ b/bakasekai/common/scripted_diplomatic_actions/BSM_custom_diplomatic_actions.txt
@@ -1,40 +1,38 @@
-scripted_diplomatic_actions = {
-    bsm_fabricate_claim_action = {
-        category = political_actions
-        name = "DIPLOMACY_BSM_FABRICATE_CLAIM_NAME"
-        icon = "GFX_goal_generic_major_power_challenge"
+bsm_fabricate_claim_action = {
+    category = political_actions
+    name = "DIPLOMACY_BSM_FABRICATE_CLAIM_NAME"
+    icon = "GFX_goal_generic_major_power_challenge"
 
-        visible = {
-            NOT = { check_variable = { ROOT = FROM } }
-            NOT = { has_war_with = FROM }
+    visible = {
+        NOT = { check_variable = { ROOT = FROM } }
+        NOT = { has_war_with = FROM }
+    }
+
+    enabled = {
+        custom_trigger_tooltip = {
+            tooltip = "BSM_FABRICATE_CLAIM_ENABLED_TOOLTIP"
+            bsm_can_initiate_fabricate_claim_diplo_action_trigger = yes
         }
+    }
 
-        enabled = {
-            custom_trigger_tooltip = {
-                tooltip = "BSM_FABRICATE_CLAIM_ENABLED_TOOLTIP"
-                bsm_can_initiate_fabricate_claim_diplo_action_trigger = yes
-            }
+    cost_string = "BSM_FABRICATE_CLAIM_DIPLO_COST"
+
+    effect = {
+        country_event = {
+            id = bsm_fabricate_claim_events.1
+            days = 1
         }
+    }
 
-        cost_string = "BSM_FABRICATE_CLAIM_DIPLO_COST"
-
-        effect = {
-            country_event = {
-                id = bsm_fabricate_claim_events.1
-                days = 1
-            }
+    ai_will_do = {
+        factor = 5
+        modifier = {
+            factor = 0
+            FROM = { is_major = yes }
         }
-
-        ai_will_do = {
-            factor = 5
-            modifier = {
-                factor = 0
-                FROM = { is_major = yes }
-            }
-            modifier = {
-                factor = 0
-                ROOT = { NOT = { check_variable = { Unified_Currency = { value > 300 } } } }
-            }
+        modifier = {
+            factor = 0
+            ROOT = { NOT = { check_variable = { Unified_Currency = { value > 300 } } } }
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove extraneous top-level wrapper in `BSM_custom_diplomatic_actions.txt`
- define `bsm_fabricate_claim_action` directly to match HOI4 expected syntax

## Testing
- `pytest` (no tests run)


------
https://chatgpt.com/codex/tasks/task_e_689deffa1eec8322bbbdc5c34fccb4b9