### PR TITLE
Add PER tag for Perche

### DIFF
--- a/bakasekai/common/countries/colors.txt
+++ b/bakasekai/common/countries/colors.txt
@@ -1164,6 +1164,10 @@ PAL = {	#パリ
 	color = rgb { 123 5 195 }
 	color_ui = rgb { 123 5 195 }
 }
+PER = {	#ペルシュ伯領
+	color = rgb { 125 85 139 }
+	color_ui = rgb { 125 85 139 }
+}
 POS = {	#シーランド
 	color = rgb { 2001 1 1 }
 	color_ui = rgb { 2001 1 1 }

--- a/bakasekai/common/country_tags/bsm_default_countries.txt
+++ b/bakasekai/common/country_tags/bsm_default_countries.txt
@@ -60,6 +60,7 @@ NYY	= "countries/Western Europe.txt"	#ニューヨークヤンキース
 OZY	= "countries/Western Europe.txt"	#オージー
 PAL	= "countries/Western Europe.txt"	#パリ
 PEG	= "countries/Western Europe.txt"	#ペンギン
+PER	= "countries/Western Europe.txt"	#ペルシュ伯領
 POS	= "countries/Western Europe.txt"	#シーランド
 SAN	= "countries/Western Europe.txt"	#サンマリノ
 SPL	= "countries/Western Europe.txt"	#南極大陸

--- a/bakasekai/history/countries/PER - Perche.txt
+++ b/bakasekai/history/countries/PER - Perche.txt
@@ -1,0 +1,16 @@
+capital = 1
+oob = "Default_oob"
+set_tech_level_1 = yes
+set_stability = 0.5
+
+set_politics = {
+    ruling_party = neutrality_ideology
+    last_election = "1933.3.5"
+    election_frequency = 48
+    elections_allowed = no
+}
+
+set_popularities = {
+    neutrality_ideology = 100
+}
+

--- a/bakasekai/localisation/japanese/map/bsm_countries_l_japanese.yml
+++ b/bakasekai/localisation/japanese/map/bsm_countries_l_japanese.yml
@@ -1173,6 +1173,10 @@
  PAL_DEF:0 "パリ"
  PAL_ADJ:0 "パリ"
  
+ PER:0 "ペルシュ伯領"
+ PER_DEF:0 "ペルシュ伯領"
+ PER_ADJ:0 "ペルシュ"
+
  POS:0 "シーランド"
  POS_DEF:0 "シーランド"
  POS_ADJ:0 "シーランド"


### PR DESCRIPTION
## Summary
- add PER country tag for Perche county
- define color and Japanese localisation for PER
- provide initial history setup for PER

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689df21332008322b9195f9e3ac7b700