### PR TITLE
ai_peace: expand ideology defaults

### DIFF
--- a/bakasekai/common/peace_conference/ai_peace/0_ideology_default.txt
+++ b/bakasekai/common/peace_conference/ai_peace/0_ideology_default.txt
@@ -1,0 +1,706 @@
+peace_ai_desires = {
+
+  generic_fascism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = fascism_ideology }
+    }
+    ai_desire = 100
+  }
+
+  generic_fascism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = fascism_ideology }
+    }
+    ai_desire = 40
+  }
+
+  generic_fascism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = fascism_ideology }
+    }
+    ai_desire = -100
+  }
+
+  generic_fascism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = fascism_ideology }
+    }
+    ai_desire = 20
+  }
+
+  generic_communism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = communism_ideology }
+    }
+    ai_desire = 30
+  }
+
+  generic_communism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = communism_ideology }
+    }
+    ai_desire = 80
+  }
+
+  generic_communism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = communism_ideology }
+    }
+    ai_desire = 60
+  }
+
+  generic_communism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = communism_ideology }
+    }
+    ai_desire = 40
+  }
+
+  generic_democratic_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = democratic_ideology }
+    }
+    ai_desire = -100
+  }
+
+  generic_democratic_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = democratic_ideology }
+    }
+    ai_desire = 40
+  }
+
+  generic_democratic_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = democratic_ideology }
+    }
+    ai_desire = 100
+  }
+
+  generic_democratic_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = democratic_ideology }
+    }
+    ai_desire = 80
+  }
+
+  generic_neutrality_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = neutrality_ideology }
+    }
+    ai_desire = 50
+  }
+
+  generic_neutrality_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = neutrality_ideology }
+    }
+    ai_desire = 30
+  }
+
+  generic_neutrality_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = neutrality_ideology }
+    }
+    ai_desire = -20
+  }
+
+  generic_neutrality_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = neutrality_ideology }
+    }
+    ai_desire = -40
+  }
+
+  generic_civilism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = civilism }
+    }
+    ai_desire = 40
+  }
+
+  generic_civilism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = civilism }
+    }
+    ai_desire = 20
+  }
+
+  generic_civilism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = civilism }
+    }
+    ai_desire = 20
+  }
+
+  generic_civilism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = civilism }
+    }
+    ai_desire = -20
+  }
+
+  generic_conservative_democracy_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = conservative_democracy }
+    }
+    ai_desire = -50
+  }
+
+  generic_conservative_democracy_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = conservative_democracy }
+    }
+    ai_desire = 40
+  }
+
+  generic_conservative_democracy_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = conservative_democracy }
+    }
+    ai_desire = 80
+  }
+
+  generic_conservative_democracy_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = conservative_democracy }
+    }
+    ai_desire = 20
+  }
+
+  generic_constitutional_monarchy_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = constitutional_monarchy }
+    }
+    ai_desire = 30
+  }
+
+  generic_constitutional_monarchy_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = constitutional_monarchy }
+    }
+    ai_desire = 50
+  }
+
+  generic_constitutional_monarchy_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = constitutional_monarchy }
+    }
+    ai_desire = 20
+  }
+
+  generic_constitutional_monarchy_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = constitutional_monarchy }
+    }
+    ai_desire = -10
+  }
+
+  generic_direct_democracy_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = direct_democracy }
+    }
+    ai_desire = -80
+  }
+
+  generic_direct_democracy_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = direct_democracy }
+    }
+    ai_desire = 30
+  }
+
+  generic_direct_democracy_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = direct_democracy }
+    }
+    ai_desire = 90
+  }
+
+  generic_direct_democracy_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = direct_democracy }
+    }
+    ai_desire = 60
+  }
+
+  generic_futurism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = futurism }
+    }
+    ai_desire = 80
+  }
+
+  generic_futurism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = futurism }
+    }
+    ai_desire = 40
+  }
+
+  generic_futurism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = futurism }
+    }
+    ai_desire = -30
+  }
+
+  generic_futurism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = futurism }
+    }
+    ai_desire = 30
+  }
+
+  generic_intellectualism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = intellectualism }
+    }
+    ai_desire = -20
+  }
+
+  generic_intellectualism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = intellectualism }
+    }
+    ai_desire = 70
+  }
+
+  generic_intellectualism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = intellectualism }
+    }
+    ai_desire = 40
+  }
+
+  generic_intellectualism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = intellectualism }
+    }
+    ai_desire = 50
+  }
+
+  generic_mythologicalism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = mythologicalism }
+    }
+    ai_desire = 50
+  }
+
+  generic_mythologicalism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = mythologicalism }
+    }
+    ai_desire = 40
+  }
+
+  generic_mythologicalism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = mythologicalism }
+    }
+    ai_desire = 10
+  }
+
+  generic_mythologicalism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = mythologicalism }
+    }
+    ai_desire = -20
+  }
+
+  generic_rightneutrality_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = rightneutrality }
+    }
+    ai_desire = 60
+  }
+
+  generic_rightneutrality_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = rightneutrality }
+    }
+    ai_desire = 40
+  }
+
+  generic_rightneutrality_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = rightneutrality }
+    }
+    ai_desire = -40
+  }
+
+  generic_rightneutrality_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = rightneutrality }
+    }
+    ai_desire = -50
+  }
+
+  generic_anarchism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = anarchism }
+    }
+    ai_desire = -70
+  }
+
+  generic_anarchism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = anarchism }
+    }
+    ai_desire = -80
+  }
+
+  generic_anarchism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = anarchism }
+    }
+    ai_desire = 100
+  }
+
+  generic_anarchism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = anarchism }
+    }
+    ai_desire = -100
+  }
+
+  generic_stupidism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = stupidism }
+    }
+    ai_desire = 40
+  }
+
+  generic_stupidism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = stupidism }
+    }
+    ai_desire = 40
+  }
+
+  generic_stupidism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = stupidism }
+    }
+    ai_desire = 40
+  }
+
+  generic_stupidism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = stupidism }
+    }
+    ai_desire = 40
+  }
+
+  generic_technicalism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = technicalism }
+    }
+    ai_desire = 30
+  }
+
+  generic_technicalism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = technicalism }
+    }
+    ai_desire = 80
+  }
+
+  generic_technicalism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = technicalism }
+    }
+    ai_desire = 10
+  }
+
+  generic_technicalism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = technicalism }
+    }
+    ai_desire = 60
+  }
+
+  generic_philanthropy_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = philanthropy }
+    }
+    ai_desire = -100
+  }
+
+  generic_philanthropy_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = philanthropy }
+    }
+    ai_desire = 30
+  }
+
+  generic_philanthropy_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = philanthropy }
+    }
+    ai_desire = 100
+  }
+
+  generic_philanthropy_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = philanthropy }
+    }
+    ai_desire = -30
+  }
+
+  generic_transformationism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = transformationism }
+    }
+    ai_desire = 20
+  }
+
+  generic_transformationism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = transformationism }
+    }
+    ai_desire = 60
+  }
+
+  generic_transformationism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = transformationism }
+    }
+    ai_desire = -20
+  }
+
+  generic_transformationism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = transformationism }
+    }
+    ai_desire = 80
+  }
+
+  generic_ruinism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = ruinism }
+    }
+    ai_desire = 90
+  }
+
+  generic_ruinism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = ruinism }
+    }
+    ai_desire = -60
+  }
+
+  generic_ruinism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = ruinism }
+    }
+    ai_desire = -100
+  }
+
+  generic_ruinism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = ruinism }
+    }
+    ai_desire = -50
+  }
+
+  generic_longitudinalism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = longitudinalism }
+    }
+    ai_desire = 70
+  }
+
+  generic_longitudinalism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = longitudinalism }
+    }
+    ai_desire = 20
+  }
+
+  generic_longitudinalism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = longitudinalism }
+    }
+    ai_desire = -30
+  }
+
+  generic_longitudinalism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = longitudinalism }
+    }
+    ai_desire = -20
+  }
+
+  generic_horizontalism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = horizontalism }
+    }
+    ai_desire = 70
+  }
+
+  generic_horizontalism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = horizontalism }
+    }
+    ai_desire = 20
+  }
+
+  generic_horizontalism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = horizontalism }
+    }
+    ai_desire = -30
+  }
+
+  generic_horizontalism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = horizontalism }
+    }
+    ai_desire = -20
+  }
+
+  generic_hinnulism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = hinnulism }
+    }
+    ai_desire = -20
+  }
+
+  generic_hinnulism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = hinnulism }
+    }
+    ai_desire = 60
+  }
+
+  generic_hinnulism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = hinnulism }
+    }
+    ai_desire = 30
+  }
+
+  generic_hinnulism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = hinnulism }
+    }
+    ai_desire = -40
+  }
+
+  generic_kyonulism_take_states = {
+    peace_action_type = take_states
+    enable = {
+      ROOT = { has_government = kyonulism }
+    }
+    ai_desire = 60
+  }
+
+  generic_kyonulism_puppet = {
+    peace_action_type = puppet
+    enable = {
+      ROOT = { has_government = kyonulism }
+    }
+    ai_desire = 50
+  }
+
+  generic_kyonulism_liberate = {
+    peace_action_type = liberate
+    enable = {
+      ROOT = { has_government = kyonulism }
+    }
+    ai_desire = -20
+  }
+
+  generic_kyonulism_force_government = {
+    peace_action_type = force_government
+    enable = {
+      ROOT = { has_government = kyonulism }
+    }
+    ai_desire = 20
+  }
+}


### PR DESCRIPTION
## Summary
- define detailed peace action desires for all ideologies, including custom ones

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68a3e7efb2e0832296b92e0ab16428d5