### PR TITLE
Remove invalid focus checks from AFG and AUS MIOs

### DIFF
--- a/bakasekai/common/military_industrial_organization/organizations/AFG_organization.txt
+++ b/bakasekai/common/military_industrial_organization/organizations/AFG_organization.txt
@@ -46,11 +46,9 @@ AFG_naval_organization = {
 		tag = AFG
 	}
 
-	available = {
-		AFG = {
-			has_completed_focus = AFG_shipyards
-		}
-	}
+  available = {
+    always = yes
+  }
 }
 
 
@@ -101,11 +99,9 @@ AFG_infantry_organization = {
 		tag = AFG
 	}
 
-	available = {
-		AFG = {
-			has_completed_focus = AFG_new_army
-		}
-	}
+  available = {
+    always = yes
+  }
 }
 
 AFG_khyber_pass_rifling_org = {
@@ -113,15 +109,13 @@ AFG_khyber_pass_rifling_org = {
 	equipment_type = { infantry_equipment }
 	research_categories = { infantry_weapons }
 
-	allowed = {	
-		has_dlc = "Graveyard of Empires"
-		tag = AFG
-	}
-	available = {
-		AFG = {
-			has_completed_focus = AFG_khyber_pass_riflining
-		}
-	}
+  allowed = {
+    has_dlc = "Graveyard of Empires"
+    tag = AFG
+  }
+  available = {
+    always = yes
+  }
 	tree_header_text = {
 		text = "Design and Production"
 		x = 3

--- a/bakasekai/common/military_industrial_organization/organizations/AUS_organization.txt
+++ b/bakasekai/common/military_industrial_organization/organizations/AUS_organization.txt
@@ -17,9 +17,9 @@ AUS_ansaldo_organization = {
 		has_dlc = "Arms Against Tyranny" 
 		has_dlc = "Gotterdammerung"
 	}
-	available = {
-		owner = { has_completed_focus = AUS_invite_foreign_tank_designers }
-	}
+  available = {
+    always = yes
+  }
 }
 
 #####################
@@ -50,23 +50,13 @@ AUS_stabilimento_tecnico_triestino_organization = {
 		}
 	}
 
-	visible = {
-		IF = {
-			limit = {
-				FROM = { original_tag = HUN } 
-			}
-			FROM = { has_completed_focus = wuw_HUN_integrate_bohemian_and_austrian_industries }
-		}
-	}
+  visible = {
+    always = yes
+  }
 
-	available = {
-		IF = {
-			limit = {
-				FROM = { original_tag = AUS } 
-			}
-			FROM = { has_completed_focus = AUS_revive_stt }
-		}
-	}
+  available = {
+    always = yes
+  }
 
 	override_trait = {
 		token = generic_mio_trait_combat_information_center
@@ -141,23 +131,13 @@ AUS_ELIN_organization = {
 		}
 	}
 
-	visible = {
-		IF = {
-			limit = {
-				FROM = { original_tag = HUN } 
-			}
-			FROM = { has_completed_focus = wuw_HUN_integrate_bohemian_and_austrian_industries }
-		}
-	}
+  visible = {
+    always = yes
+  }
 
-	available = {
-		IF = {
-			limit = {
-				FROM = { original_tag = AUS } 
-			}
-			FROM = { has_completed_focus = AUS_elin }
-		}
-	}
+  available = {
+    always = yes
+  }
 
 	initial_trait = {
 		name = AUS_mio_initial_trait_technologically_advanced_submarines
@@ -411,14 +391,9 @@ AUS_osterreichische_fleugzeugfabrik_organization = {
 		}
 	}
 
-	visible = {
-		IF = {
-			limit = {
-				FROM = { original_tag = HUN } 
-			}
-			FROM = { has_completed_focus = wuw_HUN_integrate_bohemian_and_austrian_industries }
-		}
-	}
+  visible = {
+    always = yes
+  }
 
 	add_trait = { 
 		token = AUS_mio_trait_speed_up_production
@@ -586,13 +561,13 @@ AUS_graf_and_stift_organization = {
 		has_dlc = "Arms Against Tyranny" 
 		has_dlc = "Gotterdammerung"
 	}
-	available = {
-		owner = { has_completed_focus = AUS_graf_und_stift_focus }
-	}
+  available = {
+    always = yes
+  }
 
-	visible = {
-		owner = { NOT = { has_completed_focus = AUS_saurerwerke } }
-	}
+  visible = {
+    always = yes
+  }
 
 	initial_trait = {
 		name = AUS_graf_und_stift_initial_mio_trait_speed_focused_organization
@@ -705,13 +680,13 @@ AUS_osterreichische_saurerwerke_organization = {
 		has_dlc = "La Resistance"
 
 	}
-	available = {
-		owner = { has_completed_focus = AUS_saurerwerke }
-	}
+  available = {
+    always = yes
+  }
 
-	visible = {
-		owner = { NOT = { has_completed_focus = AUS_graf_und_stift_focus } }
-	}
+  visible = {
+    always = yes
+  }
 
 	equipment_type = {
 		motorized_equipment
@@ -850,9 +825,9 @@ AUS_osterreichische_saurerwerke_organization_no_lar = {
 		has_dlc = "Gotterdammerung"
 		NOT = { has_dlc = "La Resistance" } 
 	}
-	available = {
-		owner = { has_completed_focus = AUS_saurerwerke }
-	}
+  available = {
+    always = yes
+  }
 
 	equipment_type = {
 		motorized_equipment


### PR DESCRIPTION
## Summary
- eliminate nonexistent focus requirements for Afghan naval, infantry, and rifling organizations
- remove invalid focus gates from Austrian tank, naval, submarine, aircraft, and vehicle organizations

## Testing
- `rg 'has_completed_focus' bakasekai/common/military_industrial_organization/organizations/AFG_organization.txt bakasekai/common/military_industrial_organization/organizations/AUS_organization.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a6791d816c832284616a206760fd04