### PR TITLE
Add Han successor spirit and plunder casus belli for Gandara

### DIFF
--- a/bakasekai/common/ideas/mongolia.txt
+++ b/bakasekai/common/ideas/mongolia.txt
@@ -1,2 +1,8 @@
 ideas = {
+  country = {
+    MON_han_successor = {
+      picture = generic_manpower_bonus
+      rule = { can_use_loot_wargoal = yes }
+    }
+  }
 }

--- a/bakasekai/common/war_goals/_bsm_loot_wargoal.txt
+++ b/bakasekai/common/war_goals/_bsm_loot_wargoal.txt
@@ -1,0 +1,7 @@
+loot_wargoal = {
+  war_goal_image = goal_generic_attack_allies
+  generate_wargoal_cost = 10
+  allowed = {
+    has_rule = can_use_loot_wargoal
+  }
+}

--- a/bakasekai/history/countries/MON - Gandalia.txt
+++ b/bakasekai/history/countries/MON - Gandalia.txt
@@ -5,6 +5,7 @@ land_tech_level_0 = yes
 
 add_ideas = {
 	limited_conscription
+        MON_han_successor
 }
 
 recruit_character = MON_gandara

--- a/bakasekai/localisation/english/bakasekai/mon_l_english.yml
+++ b/bakasekai/localisation/english/bakasekai/mon_l_english.yml
@@ -1,0 +1,3 @@
+﻿l_english:
+  MON_han_successor:0 "Heir to Han"
+  MON_han_successor_desc:0 ""

--- a/bakasekai/localisation/english/bakasekai/wargoals_l_english.yml
+++ b/bakasekai/localisation/english/bakasekai/wargoals_l_english.yml
@@ -1,0 +1,3 @@
+﻿l_english:
+ loot_wargoal:0 "Plunder"
+ loot_wargoal_desc:0 "Wage war to plunder the enemy."

--- a/bakasekai/localisation/japanese/bakasekai/mon_l_japanese.yml
+++ b/bakasekai/localisation/japanese/bakasekai/mon_l_japanese.yml
@@ -1,0 +1,3 @@
+﻿l_japanese:
+  MON_han_successor:0 "ハン国の後継者"
+  MON_han_successor_desc:0 ""

--- a/bakasekai/localisation/japanese/bakasekai/wargoals_l_japanese.yml
+++ b/bakasekai/localisation/japanese/bakasekai/wargoals_l_japanese.yml
@@ -1,0 +1,3 @@
+﻿l_japanese:
+ loot_wargoal:0 "略奪"
+ loot_wargoal_desc:0 "敵から財を奪うための戦争目標。"

--- a/english_files.txt
+++ b/english_files.txt
@@ -31,3 +31,5 @@ bakasekai/localisation/english/bakasekai/generic2_focus_l_english.yml
 bakasekai/localisation/english/bakasekai/drs_focus_l_english.yml
 bakasekai/localisation/english/bakasekai/drs_ideas_l_english.yml
 bakasekai/localisation/english/bakasekai/_bsm_fallen_empire_l_english.yml
+bakasekai/localisation/english/bakasekai/mon_l_english.yml
+bakasekai/localisation/english/bakasekai/wargoals_l_english.yml

--- a/japanese_files.txt
+++ b/japanese_files.txt
@@ -86,3 +86,5 @@ bakasekai/localisation/japanese/bakasekai/sys_tac_l_japanese.yml
 bakasekai/localisation/japanese/bakasekai/jpn_l_japanese.yml
 bakasekai/localisation/japanese/bakasekai/drs_focus_l_japanese.yml
 bakasekai/localisation/japanese/bakasekai/_bsm_fallen_empire_l_japanese.yml
+bakasekai/localisation/japanese/bakasekai/mon_l_japanese.yml
+bakasekai/localisation/japanese/bakasekai/wargoals_l_japanese.yml


### PR DESCRIPTION
## Summary
- add new national spirit `MON_han_successor` granting access to plunder casus belli
- implement `loot_wargoal` war goal with generic icon
- add Japanese and English localisation for the new spirit and war goal

## Testing
- `python --version`


------
https://chatgpt.com/codex/tasks/task_e_68a67f2e5be08322ab51c64336cca3d3