### PR TITLE
Fix decision and focus script errors

### DIFF
--- a/bakasekai/common/decisions/00_shipyard_lending_decisions.txt
+++ b/bakasekai/common/decisions/00_shipyard_lending_decisions.txt
@@ -62,7 +62,7 @@ shipyard_lending_category = { # カテゴリをここで参照
                         instant_build = yes #[cite: 478]
                     }
                     set_state_controller_to = FROM # 州のコントローラーをターゲット国に設定 #[cite: 476]
-                    add_state_flag = { # 貸し出し中フラグを設定 (期間付き) #[cite: 476]
+                    set_state_flag = { # 貸し出し中フラグを設定 (期間付き) #[cite: 476]
                         flag = shipyard_lending_active_flag_@FROM # ターゲット国固有のフラグ #[cite: 938]
                         days = shipyard_lending_duration # 期間は一時変数から取得 #[cite: 959]
                     }

--- a/bakasekai/common/decisions/McDonald’s_decisions.txt
+++ b/bakasekai/common/decisions/McDonald’s_decisions.txt
@@ -1866,64 +1866,68 @@ MAC_congress = {
 }
 
 MAC_oppose_move = {
-	MAC_NF_cola_capitalism = {
-		icon = ger_mefo_bills
-		available = {
+        icon = decision_political_actions
+        allowed = {
+                original_tag = MAC
+        }
+        visible = { always = yes }
 
-		}
-		ai_will_do = {
-			factor = 1
-			modifier = {
-				congress_low_support_trigger = yes
-				factor = 0
-			}
-		}
-		timeout_effect = {
-			activate_decision = MAC_NF_
-			add_ideas = MAC_e_cola_capitalism_idea
+        MAC_NF_cola_capitalism = {
+                icon = ger_mefo_bills
+                available = {
 
-		}
-		days_mission_timeout = 70
-		is_good = no
-		activation = {
-			has_country_flag = MAC_start_cola_war
-			has_country_flag = MAC_pepsi_flag
-			NOT = {
-				OR = {
-					has_country_flag = MAC_finish_cola_war
-					has_country_flag = MAC_start_cola_battle
-				}
-			}
-		}
-	}
+                }
+                ai_will_do = {
+                        factor = 1
+                        modifier = {
+                                congress_low_support_trigger = yes
+                                factor = 0
+                        }
+                }
+                timeout_effect = {
+                        add_ideas = MAC_e_cola_capitalism_idea
 
-	MAC_NF_pepsi_propaganda = {
-		icon = ger_mefo_bills
-		available = {
+                }
+                days_mission_timeout = 70
+                is_good = no
+                activation = {
+                        has_country_flag = MAC_start_cola_war
+                        has_country_flag = MAC_pepsi_flag
+                        NOT = {
+                                OR = {
+                                        has_country_flag = MAC_finish_cola_war
+                                        has_country_flag = MAC_start_cola_battle
+                                }
+                        }
+                }
+        }
 
-		}
-		ai_will_do = {
-			factor = 1
-			modifier = {
-				congress_low_support_trigger = yes
-				factor = 0
-			}
-		}
-		timeout_effect = {
-			activate_decision = MAC_NF_
+        MAC_NF_pepsi_propaganda = {
+                icon = ger_mefo_bills
+                available = {
 
-		}
-		days_mission_timeout = 70
-		is_good = no
-		activation = {
-			has_country_flag = MAC_start_cola_war
-			has_country_flag = MAC_pepsi_flag
-			NOT = {
-				OR = {
-					has_country_flag = MAC_finish_cola_war
-					has_country_flag = MAC_start_cola_battle
-				}
-			}
-		}
-	}
+                }
+                ai_will_do = {
+                        factor = 1
+                        modifier = {
+                                congress_low_support_trigger = yes
+                                factor = 0
+                        }
+                }
+                timeout_effect = {
+
+                }
+                days_mission_timeout = 70
+                is_good = no
+                activation = {
+                        has_country_flag = MAC_start_cola_war
+                        has_country_flag = MAC_pepsi_flag
+                        NOT = {
+                                OR = {
+                                        has_country_flag = MAC_finish_cola_war
+                                        has_country_flag = MAC_start_cola_battle
+                                }
+                        }
+                }
+        }
 }

--- a/bakasekai/common/decisions/emu_empire.txt
+++ b/bakasekai/common/decisions/emu_empire.txt
@@ -1,68 +1,68 @@
 EMU_decisions = {
-	EMU_mass_gathering = {
-		allowed = {
-			original_tag = EMU
-		}
-		visible = {
-			always = yes
-		}
-		political_power_cost = 100
-		complete_effect = {
-			add_to_variable = { wildness = 15 }
-			add_stability = 0.1
-			army_experience = 25
-		}
-		ai_will_do = { factor = 1 }
-	}
+        EMU_mass_gathering = {
+                allowed = {
+                        original_tag = EMU
+                }
+                visible = {
+                        always = yes
+                }
+                cost = 100
+                complete_effect = {
+                        add_to_variable = { var = wildness value = 15 }
+                        add_stability = 0.1
+                        army_experience = 25
+                }
+                ai_will_do = { factor = 1 }
+        }
 
 	EMU_analyze_human_tech = {
 		allowed = {
 			original_tag = EMU
 		}
-		visible = {
-			has_war = yes
-		}
-		political_power_cost = 75
-		complete_effect = {
-			add_to_variable = { wildness = -10 }
-			add_tech_bonus = {
-				bonus = 0.5
-				uses = 1
-				category = electronics
-			}
-		}
-		ai_will_do = { factor = 1 }
-	}
+                visible = {
+                        has_war = yes
+                }
+                cost = 75
+                complete_effect = {
+                        add_to_variable = { var = wildness value = -10 }
+                        add_tech_bonus = {
+                                bonus = 0.5
+                                uses = 1
+                                category = electronics
+                        }
+                }
+                ai_will_do = { factor = 1 }
+        }
 
-	EMU_rewild_territory = {
-		allowed = {
-			original_tag = EMU
-		}
-		visible = {
-			always = yes
-		}
-		political_power_cost = 150
-		complete_effect = {
-			add_to_variable = { wildness = 20 }
-			remove_building = { type = infrastructure level = 1 }
-			add_manpower = 5000
-		}
-		ai_will_do = { factor = 1 }
-	}
+        EMU_rewild_territory = {
+                allowed = {
+                        original_tag = EMU
+                }
+                visible = {
+                        always = yes
+                }
+                cost = 150
+                complete_effect = {
+                        add_to_variable = { var = wildness value = 20 }
+                        remove_building = { type = infrastructure level = 1 }
+                        add_manpower = 5000
+                }
+                ai_will_do = { factor = 1 }
+        }
 
 	EMU_migrate_new_lands = {
 		allowed = {
 			original_tag = EMU
 		}
-		visible = {
-			check_variable = { wildness >= 60 }
-		}
-		political_power_cost = 50
-		complete_effect = {
-			add_manpower = -50000
-			random_neighbor_country = {
-				add_opinion_modifier = { target = ROOT modifier = EMU_migration_pressure }
-			}
+                visible = {
+                        check_variable = { wildness >= 60 }
+                }
+                cost = 50
+                complete_effect = {
+                        add_manpower = -50000
+                        random_neighbor_country = {
+                                add_opinion_modifier = { target = ROOT modifier = EMU_migration_pressure }
+                        }
 		}
 		ai_will_do = { factor = 1 }
 	}
@@ -71,13 +71,13 @@ EMU_decisions = {
 		allowed = {
 			original_tag = EMU
 		}
-		visible = {
-			always = yes
-		}
-		political_power_cost = 50
-		complete_effect = {
-			add_to_variable = { wildness = -5 }
-		}
-		ai_will_do = { factor = 1 }
-	}
+                visible = {
+                        always = yes
+                }
+                cost = 50
+                complete_effect = {
+                        add_to_variable = { var = wildness value = -5 }
+                }
+                ai_will_do = { factor = 1 }
+        }
 }

--- a/bakasekai/common/decisions/malta_decisions.txt
+++ b/bakasekai/common/decisions/malta_decisions.txt
@@ -5,15 +5,15 @@ MLT_decisions = {
 		allowed = {
 			original_tag = MLT
 		}
-		available = {
-			has_idea = MLT_knights_of_malta
-			political_power > 75
-			manpower > 500
-		}
+                available = {
+                        has_idea = MLT_knights_of_malta
+                        has_political_power > 75
+                        has_manpower > 500
+                }
 		visible = {
 			has_completed_focus = MLT_restore_the_order
 		}
-		political_power_cost = 75
+                cost = 75
 		days_remove = 30
 		
 		ai_will_do = {
@@ -35,14 +35,14 @@ MLT_decisions = {
 		allowed = {
 			original_tag = MLT
 		}
-		available = {
-			has_completed_focus = MLT_fortify_malta
-			political_power > 50
-		}
+                available = {
+                        has_completed_focus = MLT_fortify_malta
+                        has_political_power > 50
+                }
 		visible = {
 			owns_state = 116
 		}
-		political_power_cost = 50
+                cost = 50
 		days_remove = 45
 		
 		ai_will_do = {

--- a/bakasekai/common/decisions/nsi_decisions.txt
+++ b/bakasekai/common/decisions/nsi_decisions.txt
@@ -9,11 +9,11 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = chikatoshi
-			political_power > 149
+			has_political_power > 149
 			num_of_controlled_states > 0
 		}
 		
-		political_power_cost = 150
+		cost = 150
 		days_remove = 60
 		
 		ai_will_do = {
@@ -45,26 +45,29 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = nsi_isolation_policy
-			political_power > 99
-			command_power > 24
+			has_political_power > 99
+			has_command_power > 24
 		}
 		
-		political_power_cost = 100
-		command_power_cost = 25
+		cost = 100
 		days_remove = 45
 		
-		ai_will_do = {
-			factor = 3
-			modifier = {
-				factor = 5
-				enemies_strength_ratio > 0.5
-			}
-		}
-		
-		remove_effect = {
-			every_owned_state = {
-				add_building_construction = {
-					type = bunker
+                ai_will_do = {
+                        factor = 3
+                        modifier = {
+                                factor = 5
+                                enemies_strength_ratio > 0.5
+                        }
+                }
+
+                complete_effect = {
+                        add_command_power = -25
+                }
+
+                remove_effect = {
+                        every_owned_state = {
+                                add_building_construction = {
+                                        type = bunker
 					level = 1
 					instant_build = yes
 				}
@@ -81,17 +84,17 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = nsi_ancestral_worship
-			political_power > 74
+			has_political_power > 74
 		}
 		
-		political_power_cost = 75
+		cost = 75
 		days_remove = 30
 		
 		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 3
-				stability < 0.7
+				has_stability < 0.7
 			}
 		}
 		
@@ -111,11 +114,11 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = nsi_forbidden_knowledge
-			political_power > 199
+			has_political_power > 199
 			num_of_research_slots > 2
 		}
 		
-		political_power_cost = 200
+		cost = 200
 		days_remove = 90
 		
 		ai_will_do = {
@@ -159,27 +162,30 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = nsi_warrior_tradition
-			manpower > 4999
-			political_power > 99
-			command_power > 49
+			has_manpower > 4999
+			has_political_power > 99
+			has_command_power > 49
 		}
 		
-		political_power_cost = 100
-		command_power_cost = 50
+		cost = 100
 		days_remove = 75
 		
-		ai_will_do = {
-			factor = 2
-			modifier = {
-				factor = 4
-				has_war = yes
-			}
-		}
-		
-		remove_effect = {
-			add_manpower = -5000
-			load_oob = "NSI_elite_reinforcements"
-			army_experience = 15
+                ai_will_do = {
+                        factor = 2
+                        modifier = {
+                                factor = 4
+                                has_war = yes
+                        }
+                }
+
+                complete_effect = {
+                        add_command_power = -50
+                }
+
+                remove_effect = {
+                        add_manpower = -5000
+                        load_oob = "NSI_elite_reinforcements"
+                        army_experience = 15
 		}
 	}
 	
@@ -192,11 +198,11 @@ NSI_internal_development = {
 		
 		available = {
 			has_idea = nsi_guardian_spirits
-			political_power > 124
+			has_political_power > 124
 			NOT = { has_war = yes }
 		}
 		
-		political_power_cost = 125
+		cost = 125
 		days_remove = 60
 		
 		ai_will_do = {
@@ -237,21 +243,24 @@ NSI_awakened_actions = {
 		available = {
 			has_idea = nsi_awakened_empire
 			has_war = yes
-			political_power > 199
-			command_power > 99
+			has_political_power > 199
+			has_command_power > 99
 		}
 		
-		political_power_cost = 200
-		command_power_cost = 100
+		cost = 200
 		days_remove = 30
 		
-		ai_will_do = {
-			factor = 5
-		}
-		
-		remove_effect = {
-			add_equipment_to_stockpile = {
-				type = infantry_equipment
+                ai_will_do = {
+                        factor = 5
+                }
+
+                complete_effect = {
+                        add_command_power = -100
+                }
+
+                remove_effect = {
+                        add_equipment_to_stockpile = {
+                                type = infantry_equipment
 				amount = 10000
 			}
 			add_equipment_to_stockpile = {
@@ -275,10 +284,10 @@ NSI_awakened_actions = {
 		available = {
 			has_idea = nsi_divine_retribution
 			has_war = yes
-			political_power > 299
+			has_political_power > 299
 		}
 		
-		political_power_cost = 300
+		cost = 300
 		days_remove = 15
 		
 		ai_will_do = {
@@ -304,10 +313,10 @@ NSI_awakened_actions = {
 		
 		available = {
 			has_idea = nsi_reality_bending
-			political_power > 499
+			has_political_power > 499
 		}
 		
-		political_power_cost = 500
+		cost = 500
 		days_remove = 120
 		
 		ai_will_do = {
@@ -340,24 +349,27 @@ NSI_awakened_actions = {
 		
 		available = {
 			has_idea = nsi_temporal_control
-			political_power > 399
-			command_power > 199
+			has_political_power > 399
+			has_command_power > 199
 		}
 		
-		political_power_cost = 400
-		command_power_cost = 200
+		cost = 400
 		days_remove = 90
 		
-		ai_will_do = {
-			factor = 2
-		}
-		
-		remove_effect = {
-			add_tech_bonus = {
-				bonus = 3.0
-				uses = 5
-				category = all
-			}
+                ai_will_do = {
+                        factor = 2
+                }
+
+                complete_effect = {
+                        add_command_power = -200
+                }
+
+                remove_effect = {
+                        add_tech_bonus = {
+                                bonus = 3.0
+                                uses = 5
+                                category = industry
+                        }
 			add_manpower = 50000
 			army_experience = 50
 			navy_experience = 50

--- a/bakasekai/common/ideas/nsi.txt
+++ b/bakasekai/common/ideas/nsi.txt
@@ -379,8 +379,8 @@ ideas = {
 				industrial_capacity_dockyard = 0.75
 				army_attack_factor = 0.5
 				army_defence_factor = 0.5
-				naval_strike_attack_factor = 0.5
-				navy_defence_factor = 0.5
+                                naval_strike_attack_factor = 0.5
+                                naval_defense_factor = 0.5
 			}
 		}
 
@@ -390,11 +390,11 @@ ideas = {
 		nsi_awakened_empire = {
 			picture = generic_strike_at_democracy1
 			removal_cost = -1
-			rule = {
-				can_declare_war = yes
-				can_join_factions = yes
-				can_create_factions = yes
-			}
+                        rule = {
+                                can_not_declare_war = no
+                                can_join_factions = yes
+                                can_create_factions = yes
+                        }
 			modifier = {
 				army_attack_factor = 0.3
 				naval_strike_attack_factor = 0.3

--- a/bakasekai/common/national_focus/McDonald_s.txt
+++ b/bakasekai/common/national_focus/McDonald_s.txt
@@ -726,17 +726,16 @@ focus_tree = {
 		search_filters = {
 			FOCUS_FILTER_POLITICAL
 		}
-		available = {
-			custom_trigger_tooltip = win_coca
-			hidden_trigger = {
-				has_country_flag = MAC_coca_cola_win
-			}
-			AND = {
-				has_completed_focus = MAC_Overseas_shop_openings
-				has_any_power_balance = no
-
-			}
-		}
+                available = {
+                        custom_trigger_tooltip = {
+                                tooltip = win_coca
+                                trigger = {
+                                        has_country_flag = MAC_coca_cola_win
+                                }
+                        }
+                        has_completed_focus = MAC_Overseas_shop_openings
+                        has_any_power_balance = no
+                }
 		prerequisite = {
 			focus = MAC_coca_cola
 		}
@@ -1882,7 +1881,7 @@ focus_tree = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				bonus = 0.3
+				cost_reduction = 0.3
 				uses = 1
 				category = air_doctrine
 			}

--- a/bakasekai/common/national_focus/WES_generic.txt
+++ b/bakasekai/common/national_focus/WES_generic.txt
@@ -307,7 +307,7 @@ focus_tree = {
 			}
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				bonus = 0.5
+				cost_reduction = 0.5
 				uses = 2
 				category = air_doctrine
 			}
@@ -423,7 +423,7 @@ focus_tree = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				bonus = 0.3
+				cost_reduction = 0.3
 				uses = 1
 				category = air_doctrine
 			}

--- a/bakasekai/common/national_focus/japan.txt
+++ b/bakasekai/common/national_focus/japan.txt
@@ -11,6 +11,24 @@ focus_tree = {
 			tag = JPN
 		}
 	}
+	#三ヵ年計画の始動
+	focus = {
+		id = JPN_launch_three_year_plan
+		icon = GFX_JPN_sankanianjihuanoshidong-331267
+		x = 15
+		y = 7
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_INDUSTRY
+		}
+		prerequisite = {
+			focus = JPN_invest_in_island_ports
+			focus = JPN_open_ports_to_allies
+		}
+		completion_reward = {
+			add_ideas = three_year_plan
+		}
+	}
 	#産業大躍進政策
        focus = {
                id = JPN_industrial_great_leap
@@ -79,22 +97,24 @@ focus_tree = {
 			add_political_power = 300
 		}
 	}
-	#三ヵ年計画の始動
+	#強い日本を、取り戻す。
 	focus = {
-		id = JPN_launch_three_year_plan
-		icon = GFX_JPN_sankanianjihuanoshidong-331267
+		id = JPN_restore_strong_japan
+		icon = GFX_JPN_qiangiribenwoqurilisu-331155
 		x = 15
-		y = 7
-		cost = 8
+		y = 3
+		cost = 10
 		search_filters = {
-			FOCUS_FILTER_INDUSTRY
+			FOCUS_FILTER_POLITICAL
 		}
 		prerequisite = {
-			focus = JPN_invest_in_island_ports
-			focus = JPN_open_ports_to_allies
+			focus = JPN_vote_civilian_party
 		}
 		completion_reward = {
-			add_ideas = three_year_plan
+			country_event = {
+				id = jpn_pol.5
+				days = 1
+			}
 		}
 	}
 	#文化活動の推奨
@@ -287,6 +307,39 @@ focus_tree = {
 		}
 		completion_reward = {
 			add_political_power = 100
+		}
+	}
+	#皇道党に投票
+	focus = {
+		id = JPN_vote_imperial_way_party
+		icon = GFX_JPN_huangdaodangnitoupiao-331135
+		x = 20
+		y = 2
+		available = {
+			always = no
+		}
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 0
+		}
+		prerequisite = {
+			focus = JPN_election_1936
+		}
+		mutually_exclusive = {
+			focus = JPN_support_vertical_party
+			focus = JPN_vote_divine_party
+			focus = JPN_vote_civilian_party
+			focus = JPN_rise_of_the_military
+		}
+		completion_reward = {
+			hidden_effect = {
+				news_event = {
+					id = jpn_news.3
+				}
+			}
 		}
 	}
 	#陛下の真意
@@ -572,6 +625,45 @@ focus_tree = {
 					level = 3
 					instant_build = yes
 					province = 13026
+				}
+			}
+		}
+	}
+	#異界の提督
+	focus = {
+		id = JPN_otherworld_admiral
+		icon = GFX_JPN_yijienotidu-331160
+		x = 4
+		y = 6
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_otherworld_commanders
+		}
+		completion_reward = {
+			if = {
+				limit = {
+					has_country_flag = JPN_tatenaga_flag
+				}
+				# recruit_character = JPN_otoko
+				# recruit_character = JPN_mitsume
+				# add_field_marshal_role = {
+				# 	character = JPN_mitsume
+				# 	skill = 4
+				# 	attack_skill = 2
+				# 	defense_skill = 3
+				# 	planning_skill = 3
+				# 	logistics_skill = 5
+				# }
+				add_naval_commander_role = {
+					Character = JPN_otoko
+					skill = 4
+					attack_skill = 2
+					defense_skill = 3
+					coordination_skill = 5
+					maneuvering_skill = 5
 				}
 			}
 		}
@@ -1547,26 +1639,6 @@ focus_tree = {
 			}
 		}
 	}
-	#強い日本を、取り戻す。
-	focus = {
-		id = JPN_restore_strong_japan
-		icon = GFX_JPN_qiangiribenwoqurilisu-331155
-		x = 15
-		y = 3
-		cost = 10
-		search_filters = {
-			FOCUS_FILTER_POLITICAL
-		}
-		prerequisite = {
-			focus = JPN_vote_civilian_party
-		}
-		completion_reward = {
-			country_event = {
-				id = jpn_pol.5
-				days = 1
-			}
-		}
-	}
 	#異界の指揮官
 	focus = {
 		id = JPN_otherworld_commanders
@@ -1665,39 +1737,6 @@ focus_tree = {
 			hidden_effect = {
 				news_event = {
 					id = jpn_news.2
-				}
-			}
-		}
-	}
-	#皇道党に投票
-	focus = {
-		id = JPN_vote_imperial_way_party
-		icon = GFX_JPN_huangdaodangnitoupiao-331135
-		x = 20
-		y = 2
-		available = {
-			always = no
-		}
-		cost = 5
-		search_filters = {
-			FOCUS_FILTER_POLITICAL
-		}
-		ai_will_do = {
-			factor = 0
-		}
-		prerequisite = {
-			focus = JPN_election_1936
-		}
-		mutually_exclusive = {
-			focus = JPN_support_vertical_party
-			focus = JPN_vote_divine_party
-			focus = JPN_vote_civilian_party
-			focus = JPN_rise_of_the_military
-		}
-		completion_reward = {
-			hidden_effect = {
-				news_event = {
-					id = jpn_news.3
 				}
 			}
 		}
@@ -1836,18 +1875,989 @@ focus_tree = {
 			}
 		}
 	}
-	#異界の提督
+	#異界の政治家
+       focus = {
+               id = JPN_otherworld_politicians
+               icon = GFX_JPN_yijienozhengzhijia-252115
+               relative_position_id = JPN_otherworld_admiral
+               x = 1
+               y = 1
+               cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_otherworld_admiral
+		}
+		mutually_exclusive = {
+			focus = JPN_mortal_politicians
+		}
+		completion_reward = {
+			hidden_effect = {
+				add_stability = -0.2
+				add_manpower = 10
+			}
+			add_political_power = 1000
+		}
+	}
+	#儀式の結末
+       focus = {
+               id = JPN_ritual_outcome
+               icon = GFX_JPN_yishinojiemo-331161
+               relative_position_id = JPN_otherworld_politicians
+               x = -1
+               y = 1
+               cost = 5
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_mortal_politicians
+			focus = JPN_otherworld_politicians
+		}
+		completion_reward = {
+			add_ideas = {
+				heavy_responsibility
+			}
+		}
+	}
+	#縦にっ!
 	focus = {
-		id = JPN_otherworld_admiral
-		icon = GFX_JPN_yijienotidu-331160
-		x = 4
-		y = 6
+		id = JPN_go_vertical
+		icon = GFX_JPN_zongnitu-331164
+		x = 1
+		y = 8
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_invest_in_tall_cities
+		}
+		completion_reward = {
+			add_command_power = 120
+			country_event = {
+				id = jpn_pol.2
+			}
+		}
+	}
+	#日本横断工業地帯
+	focus = {
+		id = JPN_transjapan_industrial_zone
+		icon = GFX_JPN_ribenhengduangongyedidai-331165
+		x = 1
+		y = 9
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_INDUSTRY
+		}
+		prerequisite = {
+			focus = JPN_go_vertical
+		}
+		completion_reward = {
+			add_political_power = 120
+			add_ideas = {
+				factory_plan
+			}
+		}
+	}
+	#北極への挑戦
+	focus = {
+		id = JPN_challenge_the_arctic
+		icon = GFX_JPN_beijihenotiaozhan-331166
+		x = 5
+		y = 9
 		cost = 7
 		search_filters = {
 			FOCUS_FILTER_WAR_SUPPORT
 		}
 		prerequisite = {
-			focus = JPN_otherworld_commanders
+			focus = JPN_ritual_outcome
+		}
+		completion_reward = {
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = PRK
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = USA
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = NOR
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = POL
+			}
+		}
+	}
+	#南進せよ
+	focus = {
+		id = JPN_push_southward
+		icon = GFX_focus_hol_war_on_pacifism
+		x = 3
+		y = 9
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_ritual_outcome
+		}
+		completion_reward = {
+			add_named_threat = {
+				threat = 10
+				name = JP_E_W
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = SPL
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = UTP
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = FRP
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = IDN
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = CCS
+			}
+		}
+	}
+	#計画の完遂
+	focus = {
+		id = JPN_complete_the_plan
+		icon = GFX_JPN_jihuanowansui-252124
+		x = 3
+		y = 10
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_challenge_the_arctic
+		}
+		prerequisite = {
+			focus = JPN_push_southward
+		}
+		prerequisite = {
+			focus = JPN_transjapan_industrial_zone
+		}
+		completion_reward = {
+			add_political_power = 300
+		}
+	}
+	#次期選挙
+	focus = {
+		id = JPN_next_election
+		icon = GFX_JPN_ciqixuanju-331168
+		x = 11
+		y = 11
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_complete_the_plan
+			focus = JPN_imperial_conference
+			focus = JPN_policy_conference
+			# focus = JPN_collapse
+		}
+		completion_reward = {
+		}
+	}
+	#神聖教育
+	focus = {
+		id = JPN_sacred_education
+		icon = GFX_JPN_shenshengjiaoyu-331184
+		x = 8
+		y = 3
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_RESEARCH
+		}
+		prerequisite = {
+			focus = JPN_vote_divine_party
+		}
+		completion_reward = {
+			add_ideas = JAP_supremacy_of_technology_w
+			add_research_slot = 1
+		}
+	}
+	#可愛いリーダー
+	focus = {
+		id = JPN_invite_cute_leader
+		icon = GFX_JPN_keaiirida-331185
+		x = 8
+		y = 4
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_sacred_education
+		}
+		available = {
+			has_country_flag = JPN_kami_flag
+		}
+		completion_reward = {
+			add_popularity = {
+				ideology = mythologicalism
+				popularity = 0.5
+			}
+			set_country_leader_ideology = shinto
+			set_politics = {
+				ruling_party = mythologicalism
+				elections_allowed = yes
+			}
+			promote_character = {
+				character = JPN_Amaterasu
+				ideology = shinto
+			}
+			hidden_effect = {
+				add_ideas = JAP_hirohito
+				# complete_national_focus = JPN_summon_conceptual_leader
+			}
+		}
+	}
+	#平和主義
+	focus = {
+		id = JPN_embrace_pacifism
+		icon = GFX_JPN_pinghezhuyi-331186
+		x = 7
+		y = 5
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_STABILITY
+		}
+		prerequisite = {
+			focus = JPN_invite_cute_leader
+		}
+		mutually_exclusive = {
+			focus = JPN_embrace_expansionism
+		}
+		completion_reward = {
+			set_country_flag = JPN_heiwa
+			add_political_power = 100
+		}
+	}
+	#拡張主義
+	focus = {
+		id = JPN_embrace_expansionism
+		icon = GFX_JPN_kuozhangzhuyi-331187
+		x = 9
+		y = 5
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_invite_cute_leader
+		}
+		mutually_exclusive = {
+			focus = JPN_embrace_pacifism
+		}
+		completion_reward = {
+			set_country_flag = JPN_kakutyo
+			add_command_power = 120
+		}
+	}
+	#研究への投資
+	focus = {
+		id = JPN_invest_in_research
+		icon = GFX_JPN_yanjiuhenotouzi-252170
+		x = 8
+		y = 6
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_RESEARCH
+		}
+		prerequisite = {
+			focus = JPN_embrace_pacifism
+			focus = JPN_embrace_expansionism
+		}
+		completion_reward = {
+			add_tech_bonus = {
+				bonus = 0.25
+				uses = 2
+				category = electronics
+			}
+			if = {
+				limit = {
+					has_country_flag = JPN_heiwa
+				}
+				add_tech_bonus = {
+					bonus = 0.25
+					uses = 2
+					category = industry
+				}
+			}
+			else_if = {
+				limit = {
+					has_country_flag = JPN_kakutyo
+				}
+				add_tech_bonus = {
+					bonus = 0.25
+					uses = 2
+					category = infantry_tech
+				}
+			}
+		}
+	}
+	#アジア圏との協調
+	focus = {
+		id = JPN_cooperate_with_asia
+		icon = GFX_focus_chi_collaboration_with_the_japanese
+		x = 7
+		y = 7
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_MANPOWER
+		}
+		prerequisite = {
+			focus = JPN_embrace_pacifism
+		}
+		prerequisite = {
+			focus = JPN_invest_in_research
+		}
+		completion_reward = {
+			if = {
+				limit = {
+					has_country_flag = JPN_heiwa
+				}
+				add_political_power = 100
+			}
+			else_if = {
+				limit = {
+					has_country_flag = JPN_kakutyo
+				}
+				add_command_power = 60
+			}
+			hidden_effect = {
+				add_relation_modifier = {
+					target = CHI
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = SCC
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = UTP
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = SCC
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = IDN
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = BKK
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = VNM
+					modifier = East_Asian_Accord
+				}
+				add_relation_modifier = {
+					target = HAW
+					modifier = East_Asian_Accord
+				}
+				create_faction = East_Asian_Alignment
+				add_to_faction = CHI
+				# CC
+				add_to_faction = UTP
+				add_to_faction = SCC
+				add_to_faction = IDN
+				add_to_faction = BKK
+				add_to_faction = VNM
+				add_to_faction = HAW
+			}
+		}
+	}
+	#楽園への侵攻
+	focus = {
+		id = JPN_invade_paradise
+		icon = GFX_focus_usa_focus_on_asia
+		x = 9
+		y = 7
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_embrace_expansionism
+		}
+		prerequisite = {
+			focus = JPN_invest_in_research
+		}
+		completion_reward = {
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = UTP
+			}
+		}
+	}
+	#生身の政治家
+	focus = {
+		id = JPN_mortal_politicians
+		icon = GFX_focus_eng_concessions_to_the_trade_unions
+		x = 3
+		y = 7
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_otherworld_admiral
+		}
+		mutually_exclusive = {
+			focus = JPN_otherworld_politicians
+		}
+		completion_reward = {
+			add_political_power = 300
+		}
+	}
+	#縦に長い都市に投資
+	focus = {
+		id = JPN_invest_in_tall_cities
+		icon = GFX_JPN_zongnichangidushinitouzi-73987
+		x = 1
+		y = 6
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_INDUSTRY
+		}
+		prerequisite = {
+			focus = JPN_vertical_government
+		}
+		completion_reward = {
+			add_political_power = -200
+			add_ideas = {
+				vertical_cities
+			}
+		}
+	}
+	#縦長行政
+	focus = {
+		id = JPN_vertical_government
+		icon = GFX_JPN_zongchangxingzheng-331159
+		x = 1
+		y = 5
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_vertical_education
+		}
+		prerequisite = {
+			focus = JPN_abandon_okinawa
+		}
+		completion_reward = {
+			swap_ideas = {
+				remove_idea = sudden_change_of_policy
+				add_idea = vertical_administration
+			}
+		}
+	}
+	#家庭裁判所の設置
+	focus = {
+		id = JPN_establish_family_courts
+		icon = GFX_JPN_jiatingcaipansuonoshezhi-331274
+		x = 11
+		y = 8
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_STABILITY
+		}
+		prerequisite = {
+			focus = JPN_education_reform
+		}
+		completion_reward = {
+			add_ideas = family_court
+		}
+	}
+	#子育て家庭への支援
+	focus = {
+		id = JPN_support_families
+		icon = GFX_JPN_ziyutejiatinghenozhiyuan-331275
+		x = 11
+		y = 9
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_MANPOWER
+		}
+		prerequisite = {
+			focus = JPN_establish_family_courts
+		}
+		completion_reward = {
+			add_ideas = famillllllllllly
+		}
+	}
+	#研究の加速
+	focus = {
+		id = JPN_accelerate_research
+		icon = GFX_JPN_yanjiunojiasu-252171
+		x = 8
+		y = 8
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_RESEARCH
+		}
+		prerequisite = {
+			focus = JPN_invade_paradise
+			focus = JPN_cooperate_with_asia
+		}
+		completion_reward = {
+			add_research_slot = 1
+		}
+	}
+	#共栄圏の拡大
+	focus = {
+		id = JPN_expand_co_prosperity_sphere
+		icon = GFX_JPN_gongrongquannokuoda-331191
+		x = 7
+		y = 9
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_cooperate_with_asia
+		}
+		prerequisite = {
+			focus = JPN_accelerate_research
+		}
+		completion_reward = {
+			add_ideas = JPN_large_asean
+			add_political_power = 777
+		}
+	}
+	#中小国を恫喝
+	focus = {
+		id = JPN_threaten_small_nations
+		icon = GFX_JPN_zhongxiaoguowotonghe-331198
+		x = 9
+		y = 9
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_invade_paradise
+		}
+		prerequisite = {
+			focus = JPN_accelerate_research
+		}
+		completion_reward = {
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = PRK
+			}
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = SOV
+			}
+		}
+	}
+	#古き同盟の回生
+	focus = {
+		id = JPN_revive_old_alliance
+		icon = GFX_focus_eng_the_sun_never_sets
+		x = 13
+		y = 4
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_restore_strong_japan
+		}
+		mutually_exclusive = {
+			focus = JPN_island_union
+		}
+		completion_reward = {
+			add_political_power = 100
+			set_country_flag = JPN_ENG
+			country_event = {
+				id = jpn_pol.3
+				days = 1
+			}
+		}
+	}
+	#諸島連合
+	focus = {
+		id = JPN_island_union
+		icon = GFX_JPN_zhudaolianhe-331210
+		x = 17
+		y = 4
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_restore_strong_japan
+		}
+		mutually_exclusive = {
+			focus = JPN_revive_old_alliance
+		}
+		completion_reward = {
+			add_political_power = 100
+			set_country_flag = ASEAN
+			
+			# 既存陣営から脱退し、新陣営を作成
+			if = {
+				limit = {
+					is_in_faction = yes
+					is_faction_leader = no
+				}
+				leave_faction = yes
+			}
+			if = {
+				limit = {
+					is_in_faction = yes
+					is_faction_leader = yes
+				}
+				dismantle_faction = yes
+			}
+			
+			# 新陣営作成
+			create_faction = ASEAN_2
+			add_to_faction = TWN
+			add_to_faction = NSI
+			add_to_faction = GMI
+			add_to_faction = HAW
+			add_to_faction = SJK
+			add_to_faction = DRS
+			add_to_faction = ECU
+			
+			# 陣営内での相互保証（自分以外）
+			hidden_effect = {
+				every_country = {
+					limit = {
+						is_in_faction_with = JPN
+						NOT = { tag = JPN }
+					}
+					save_event_target_as = current_faction_member
+					every_country = {
+						limit = {
+							is_in_faction_with = JPN
+							NOT = { tag = JPN }
+							NOT = { tag = event_target:current_faction_member }
+						}
+						give_guarantee = event_target:current_faction_member
+					}
+					# 日本への保証
+					give_guarantee = JPN
+				}
+				# 日本から他メンバーへの保証
+				every_country = {
+					limit = {
+						is_in_faction_with = JPN
+						NOT = { tag = JPN }
+					}
+					ROOT = { give_guarantee = PREV }
+				}
+			}
+		}
+	}
+	#合同演習
+	focus = {
+		id = JPN_joint_exercises
+		icon = GFX_JPN_hetongyanxi-331213
+		x = 15
+		y = 5
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_revive_old_alliance
+			focus = JPN_island_union
+		}
+		completion_reward = {
+			if = {
+				limit = {
+					has_country_flag = JPN_ENG
+				}
+				GBR = {
+					army_experience = 100
+					air_experience = 100
+				}
+				every_country = {
+					limit = {
+						is_in_faction_with = JPN
+					}
+					army_experience = 100
+					air_experience = 100
+				}
+				every_country = {
+					limit = {
+						is_in_faction_with = GBR
+					}
+					army_experience = 100
+					air_experience = 100
+				}
+			}
+			else_if = {
+				limit = {
+					has_country_flag = ASEAN
+				}
+				every_country = {
+					limit = {
+						is_in_faction_with = JPN
+					}
+					every_country = {
+						limit = {
+							is_in_faction_with = GBR
+						}
+						army_experience = 100
+						air_experience = 100
+					}
+				}
+				set_faction_spymaster = yes
+			}
+		}
+	}
+	#連合への港解放
+	focus = {
+		id = JPN_open_ports_to_allies
+		icon = GFX_JPN_lianhehenogangjiefang-331214
+		x = 13
+		y = 6
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_revive_old_alliance
+		}
+		prerequisite = {
+			focus = JPN_joint_exercises
+		}
+		completion_reward = {
+			give_military_access = GBR
+			navy_experience = 100
+			every_country = {
+				limit = {
+					is_in_faction_with = JPN
+				}
+				every_country = {
+					limit = {
+						is_in_faction_with = GBR
+					}
+					give_military_access = PREV
+				}
+			}
+		}
+	}
+	#諸島港湾への投資
+	focus = {
+		id = JPN_invest_in_island_ports
+		icon = GFX_JPN_zhudaogangwanhenotouzi-331218
+		x = 17
+		y = 6
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_island_union
+		}
+		prerequisite = {
+			focus = JPN_joint_exercises
+		}
+		completion_reward = {
+			random_owned_state = {
+				limit = {
+					is_coastal = yes
+				}
+				set_building_level = {
+					type = naval_base
+					level = 3
+					instant_build = yes
+					# province = {
+					# 	level = 0
+					# }
+				}
+			}
+			random_owned_state = {
+				limit = {
+					is_coastal = yes
+				}
+				set_building_level = {
+					type = naval_base
+					level = 3
+					instant_build = yes
+					# province = {
+					# 	level = 0
+					# }
+				}
+			}
+			random_owned_state = {
+				limit = {
+					is_coastal = yes
+				}
+				set_building_level = {
+					type = naval_base
+					level = 3
+					instant_build = yes
+					# province = {
+					# 	level = 0
+					# }
+				}
+			}
+		}
+	}
+	#沖縄の放棄
+	focus = {
+		id = JPN_abandon_okinawa
+		icon = GFX_JPN_chongnawanofangqi-331158
+		x = 0
+		y = 4
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_kuril_garrison
+		}
+		completion_reward = {
+			526 = {
+				transfer_state_to = ORI
+				add_core_of = ORI
+				remove_core_of = JPN
+			}
+			hidden_effect = {
+				ORI = {
+					add_manpower = 3500
+				}
+				526 = {
+					set_state_name = RYUKYU_STATE_NAME
+				}
+			}
+		}
+	}
+	#指導者の概念化
+	focus = {
+		id = JPN_conceptualize_leadership
+		icon = GFX_JPN_zhidaozhenogainianhua-331141
+		x = 2
+		y = 3
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_support_vertical_party
+		}
+		completion_reward = {
+			set_country_flag = JPN_tatenaga_flag
+			promote_character = {
+				character = JPN_tate
+				ideology = anti_horizontalism
+			}
+		}
+	}
+	#千島駐屯地
+	focus = {
+		id = JPN_kuril_garrison
+		icon = GFX_JPN_qiandaozhutundi-331146
+		x = 0
+		y = 3
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_support_vertical_party
+		}
+		completion_reward = {
+			861 = {
+				add_building_construction = {
+					type = bunker
+					level = 3
+					instant_build = yes
+					province = {
+						all_provinces = yes
+					}
+				}
+			}
+		}
+	}
+	#召喚準備
+	focus = {
+		id = JPN_prepare_summoning
+		icon = GFX_JPN_zhaohuanzhunbei-331150
+		x = 4
+		y = 3
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_vote_divine_party
+		}
+		completion_reward = {
+			set_country_flag = JPN_kami_flag
+			add_political_power = 120
+		}
+	}
+	#概念上の指導者
+	focus = {
+		id = JPN_summon_conceptual_leader
+		icon = GFX_JPN_gainianshangnozhidaozhe-331154
+		x = 4
+		y = 4
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_prepare_summoning
+			focus = JPN_conceptualize_leadership
+		}
+		completion_reward = {
+			if = {
+				limit = {
+					has_country_flag = JPN_tatenaga_flag
+				}
+				add_country_leader_trait = tatenaga
+				add_political_power = 100
+			}
+			else_if = {
+				limit = {
+					has_country_flag = JPN_kami_flag
+				}
+				complete_national_focus = JPN_invite_cute_leader
+			}
+		}
+	}
+	#異界の指揮官
+	focus = {
+		id = JPN_otherworld_commanders
+		icon = GFX_JPN_yijienozhihuiguan-331156
+		x = 4
+		y = 5
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_WAR_SUPPORT
+		}
+		prerequisite = {
+			focus = JPN_summon_conceptual_leader
 		}
 		completion_reward = {
 			if = {
@@ -1856,22 +2866,219 @@ focus_tree = {
 				}
 				# recruit_character = JPN_otoko
 				# recruit_character = JPN_mitsume
-				# add_field_marshal_role = {
-				# 	character = JPN_mitsume
+				add_field_marshal_role = {
+					character = JPN_mitsume
+					skill = 4
+					attack_skill = 2
+					defense_skill = 3
+					planning_skill = 3
+					logistics_skill = 5
+				}
+				# add_naval_commander_role = {
+				# 	Character = JPN_otoko
 				# 	skill = 4
 				# 	attack_skill = 2
 				# 	defense_skill = 3
 				# 	planning_skill = 3
 				# 	logistics_skill = 5
 				# }
-				add_naval_commander_role = {
-					Character = JPN_otoko
-					skill = 4
-					attack_skill = 2
-					defense_skill = 3
-					coordination_skill = 5
-					maneuvering_skill = 5
+			}
+			add_political_power = 100
+		}
+	}
+	#縦長的教育
+	focus = {
+		id = JPN_vertical_education
+		icon = GFX_JPN_zongchangdejiaoyu-331157
+		x = 2
+		y = 4
+		cost = 8
+		search_filters = {
+			FOCUS_FILTER_RESEARCH
+		}
+		prerequisite = {
+			focus = JPN_conceptualize_leadership
+		}
+		completion_reward = {
+			add_ideas = {
+				vertical_education
+			}
+		}
+	}
+	#進神党に投票
+	focus = {
+		available = {
+			always = no
+		}
+		id = JPN_vote_divine_party
+		icon = GFX_JPN_jinshendangnitoupiao-331134
+		x = 6
+		y = 2
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 60
+		}
+		prerequisite = {
+			focus = JPN_election_1936
+		}
+		mutually_exclusive = {
+			focus = JPN_vote_imperial_way_party
+		}
+		mutually_exclusive = {
+			focus = JPN_vote_civilian_party
+		}
+		mutually_exclusive = {
+			focus = JPN_rise_of_the_military
+		}
+		mutually_exclusive = {
+			focus = JPN_support_vertical_party
+		}
+		completion_reward = {
+			add_political_power = -90
+			add_timed_idea = {
+				idea = sudden_change_of_policy
+				days = 45
+			}
+			hidden_effect = {
+				news_event = {
+					id = jpn_news.2
 				}
+			}
+		}
+	}
+	#民政党に投票
+	focus = {
+		id = JPN_vote_civilian_party
+		icon = GFX_JPN_minzhengdangnitoupiao-331136
+		x = 15
+		available = {
+			always = no
+		}
+		y = 2
+		cost = 7
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 100
+		}
+		prerequisite = {
+			focus = JPN_election_1936
+		}
+		mutually_exclusive = {
+			focus = JPN_support_vertical_party
+			focus = JPN_vote_divine_party
+			focus = JPN_vote_imperial_way_party
+			focus = JPN_rise_of_the_military
+		}
+		completion_reward = {
+			hidden_effect = {
+				news_event = {
+					id = jpn_news.5
+				}
+			}
+		}
+	}
+	#軍部の台頭
+	focus = {
+		id = JPN_rise_of_the_military
+		icon = GFX_JPN_junbunotaitou-331137
+		x = 24
+		y = 2
+		available = {
+			always = no
+		}
+		cost = 10
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 0
+		}
+		prerequisite = {
+			focus = JPN_election_1936
+		}
+		mutually_exclusive = {
+			focus = JPN_support_vertical_party
+			focus = JPN_vote_divine_party
+			focus = JPN_vote_imperial_way_party
+			focus = JPN_vote_civilian_party
+		}
+	}
+	#日本の運命
+	focus = {
+		id = JPN_fate_of_japan
+		icon = GFX_focus_jap_pacific_guardian
+		x = 11
+		y = 0
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 100
+		}
+		completion_reward = {
+			add_political_power = 200
+		}
+	}
+	#縦長党を支持
+	focus = {
+		available = {
+			always = no
+		}
+		id = JPN_support_vertical_party
+		icon = GFX_JPN_zongchangdangwozhichi-331128
+		x = 1
+		y = 2
+		cost = 6
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		ai_will_do = {
+			factor = 40
+		}
+		prerequisite = {
+			focus = JPN_election_1936
+		}
+		mutually_exclusive = {
+			focus = JPN_vote_divine_party
+			focus = JPN_vote_imperial_way_party
+			focus = JPN_vote_civilian_party
+			focus = JPN_rise_of_the_military
+		}
+		completion_reward = {
+			add_political_power = -120
+			add_timed_idea = {
+				idea = sudden_change_of_policy
+				days = 90
+			}
+			hidden_effect = {
+				news_event = {
+					id = jpn_news.1
+				}
+			}
+		}
+	}
+	#1936年選挙
+	focus = {
+		id = JPN_election_1936
+		icon = GFX_senkyo
+		x = 11
+		y = 1
+		cost = 5
+		search_filters = {
+			FOCUS_FILTER_POLITICAL
+		}
+		prerequisite = {
+			focus = JPN_fate_of_japan
+		}
+		completion_reward = {
+			country_event = {
+				id = jpn_pol.1
+				days = 1
 			}
 		}
 	}

--- a/bakasekai/common/national_focus/malta.txt
+++ b/bakasekai/common/national_focus/malta.txt
@@ -197,15 +197,15 @@ focus_tree = {
 		ai_will_do = {
 			factor = 10
 		}
-		completion_reward = {
-			add_tech_bonus = {
-				name = MLT_modern_knights
-				bonus = 0.5
-				uses = 1
-				category = marines_tech
-			}
-		}
-	}
+                completion_reward = {
+                        add_tech_bonus = {
+                                name = MLT_modern_knights
+                                bonus = 0.5
+                                uses = 1
+                                category = special_forces
+                        }
+                }
+        }
 
 	focus = {
 		id = MLT_mediterranean_trade

--- a/bakasekai/common/national_focus/nsi.txt
+++ b/bakasekai/common/national_focus/nsi.txt
@@ -73,17 +73,20 @@ focus_tree = {
 		prerequisite = {
 			focus = NSI_isolation_doctrine
 		}
-		completion_reward = {
-			add_ideas = nsi_outsider_rejection
-			add_building_construction = {
-				type = coastal_fort
-				level = 3
-				province = {
-					all_provinces = yes
-					limit_to_naval_base = yes
-				}
-			}
-		}
+                completion_reward = {
+                        add_ideas = nsi_outsider_rejection
+                        every_owned_state = {
+                                limit = {
+                                        is_coastal = yes
+                                        has_naval_base > 0
+                                }
+                                add_building_construction = {
+                                        type = coastal_bunker
+                                        level = 3
+                                        instant_build = yes
+                                }
+                        }
+                }
 	}
 
 	focus = {
@@ -218,7 +221,7 @@ focus_tree = {
 				if = {
 					limit = { is_coastal = yes }
 					add_building_construction = {
-						type = coastal_fort
+						type = coastal_bunker
 						level = 3
 						instant_build = yes
 					}
@@ -682,7 +685,7 @@ focus_tree = {
 				name = secret_tech_bonus
 				bonus = 1.5
 				uses = 2
-				category = concentrated_industry
+				category = industry
 			}
 			add_ideas = nsi_mystical_sciences
 		}
@@ -744,21 +747,24 @@ focus_tree = {
 		prerequisite = {
 			focus = NSI_spiritual_awakening
 		}
-		completion_reward = {
-			add_ideas = nsi_divine_protection
-			every_owned_state = {
-				add_building_construction = {
-					type = bunker
-					level = 5
-					instant_build = yes
-				}
-				add_building_construction = {
-					type = coastal_fort
-					level = 5
-					instant_build = yes
-				}
-			}
-		}
+                completion_reward = {
+                        add_ideas = nsi_divine_protection
+                        every_owned_state = {
+                                add_building_construction = {
+                                        type = bunker
+                                        level = 5
+                                        instant_build = yes
+                                }
+                                if = {
+                                        limit = { is_coastal = yes }
+                                        add_building_construction = {
+                                                type = coastal_bunker
+                                                level = 5
+                                                instant_build = yes
+                                        }
+                                }
+                        }
+                }
 	}
 
 	focus = {
@@ -831,7 +837,7 @@ focus_tree = {
 				name = temporal_bonus
 				bonus = 5.0
 				uses = 10
-				category = all
+				category = industry
 			}
 			add_manpower = 200000
 		}


### PR DESCRIPTION
## Summary
- normalize NSI, Malta, and EMU decisions to use valid costs, triggers, and category definitions
- clean up McDonald’s cola war missions and NSI shipyard lending effects so they no longer reference invalid handlers
- correct focus tech bonuses and anchor focus ordering for Japan, NSI, Malta, and WES trees to remove parsing errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67833e6d48322bf21a5fd960d0d7a