### PR TITLE
Add DIS North America conquest super event

### DIFF
--- a/bakasekai/common/on_actions/_bsm_system.txt
+++ b/bakasekai/common/on_actions/_bsm_system.txt
@@ -343,6 +343,21 @@ on_actions = {
                     National_Unity_Power = Cultural_Degree
                 }
             }
+            if = {
+                limit = {
+                    country_exists = DIS
+                }
+                DIS = {
+                    if = {
+                        limit = {
+                            NOT = { has_country_flag = DIS_super_event_north_america_fired }
+                            dis_controls_north_america = yes
+                        }
+                        set_country_flag = DIS_super_event_north_america_fired
+                        news_event = { id = baka_super_news.8 }
+                    }
+                }
+            }
         }
     }
     on_nuke_drop = {

--- a/bakasekai/common/scripted_guis/super_events.txt
+++ b/bakasekai/common/scripted_guis/super_events.txt
@@ -56,6 +56,12 @@ scripted_gui = {
 			}
 		}
 
+		triggers = {
+			Super_Event_Image_Disney_visible = {
+				has_country_flag = DIS_North_America
+			}
+		}
+
 		############
 		###BUTTON###
 		############
@@ -118,6 +124,13 @@ scripted_gui = {
 						has_country_flag = spflag_YAAI
 					}
 					clr_country_flag = spflag_YAAI
+				}
+
+				if = {
+					limit = {
+						has_country_flag = DIS_North_America
+					}
+					clr_country_flag = DIS_North_America
 				}
 			}
 		}

--- a/bakasekai/common/scripted_localisation/Super_Event_Scripted_Loc.txt
+++ b/bakasekai/common/scripted_localisation/Super_Event_Scripted_Loc.txt
@@ -58,6 +58,13 @@ defined_text = {
         localization_key = "sp_event_YAAI"
     }
 
+    text = {
+        trigger = {
+            has_country_flag = DIS_North_America
+        }
+        localization_key = "sp_event_DIS_North_America"
+    }
+
 }
 
 #Remarks
@@ -119,6 +126,13 @@ defined_text = {
         }
         localization_key = "sp_event_YAAI_REMARK"
     }
+
+    text = {
+        trigger = {
+            has_country_flag = DIS_North_America
+        }
+        localization_key = "sp_event_DIS_North_America_REMARK"
+    }
 }
 
 #Quotes
@@ -179,6 +193,13 @@ defined_text = {
             has_country_flag = spflag_YAAI
         }
         localization_key = "sp_event_YAAI_QUOTE"
+    }
+
+    text = {
+        trigger = {
+            has_country_flag = DIS_North_America
+        }
+        localization_key = "sp_event_DIS_North_America_QUOTE"
     }
 
 }

--- a/bakasekai/common/scripted_triggers/bsm_scripted_triggers.txt
+++ b/bakasekai/common/scripted_triggers/bsm_scripted_triggers.txt
@@ -56,3 +56,19 @@ bsm_can_fabricate_claim_on_this_state_in_event_trigger = {
         is_coastal = yes
     }
 }
+# ディズニーランドが北米大陸を完全支配しているかどうか
+# DIS限定のチェックであり、北米大陸のいずれかの州がDIS以外に支配されていれば失敗する
+# 大陸判定はis_on_continent = north_americaを利用する
+# 将来的に他国でも再利用する場合はROOT参照に置き換えること
+# ここではシンプルにDIS専用で十分
+# NOTE: すべての北米州に支配国が存在することを前提としている（HOI4デフォルト仕様）
+dis_controls_north_america = {
+    NOT = {
+        any_state = {
+            limit = {
+                is_on_continent = north_america
+            }
+            NOT = { is_controlled_by = DIS }
+        }
+    }
+}

--- a/bakasekai/events/BAKA_SuperEvents.txt
+++ b/bakasekai/events/BAKA_SuperEvents.txt
@@ -162,3 +162,22 @@ country_event = {
 		play_song = "music_you_are_an_idiot"
 	}
 }
+
+country_event = {
+        #DIS conquers North America
+        id = baka_super.9
+        title = baka_super.9.t
+        desc = baka_super.9.d
+        picture = GFX_report_event_diplomatic_message
+        is_triggered_only = yes
+        fire_only_once = yes
+        hidden = yes
+        trigger = {
+        }
+        option = {
+                name = baka_super.9.a
+                set_country_flag = DIS_North_America
+                set_country_flag = Super_Event_Visible
+                play_song = "miniature_land"
+        }
+}

--- a/bakasekai/events/Baka_Super_News.txt
+++ b/bakasekai/events/Baka_Super_News.txt
@@ -291,3 +291,40 @@ news_event = {
 		}
 	}
 }
+news_event = {
+        id = baka_super_news.8
+        title = baka_super_news.8.t
+        desc = baka_super_news.8.desc
+
+        is_triggered_only = yes
+
+        fire_only_once = yes
+
+        hidden = yes
+
+        option = {
+                name = baka_super_news.8.a
+                trigger = {
+                        TAG = DIS
+                }
+                hidden_effect = {
+                        ROOT = {
+                                country_event = { id = baka_super.9 }
+                        }
+                }
+        }
+
+        option = {
+                name = baka_super_news.8.b
+                trigger = {
+                        NOT = {
+                                TAG = DIS
+                        }
+                }
+                hidden_effect = {
+                        ROOT = {
+                                country_event = { id = baka_super.9 }
+                        }
+                }
+        }
+}

--- a/bakasekai/interface/BSM_super.gfx
+++ b/bakasekai/interface/BSM_super.gfx
@@ -43,4 +43,8 @@ spriteTypes = {
 		name = "GFX_sp_event_No_Economy"
 		textureFile = "/gfx/sp_events/No_Economy.dds"
 	}
+	spriteType = {
+		name = "GFX_sp_event_Disney"
+		textureFile = "/gfx/sp_events/MC_Donald.dds"
+	}
 }

--- a/bakasekai/interface/BSM_super.gui
+++ b/bakasekai/interface/BSM_super.gui
@@ -69,6 +69,12 @@ guiTypes = {
 			position = {x = 0 y = 0}
 		}
 
+		iconType = {
+			name = "Super_Event_Image_Disney"
+			spriteType = "GFX_sp_event_Disney"
+			position = {x = 0 y = 0}
+		}
+
 		
 		#############
 		##INTERFACE##

--- a/bakasekai/localisation/japanese/replace/bakasekai/super_localisation_l_japanese.yml
+++ b/bakasekai/localisation/japanese/replace/bakasekai/super_localisation_l_japanese.yml
@@ -30,3 +30,7 @@
   sp_event_YAAI: "you are an idiot"
   sp_event_YAAI_QUOTE: "you are an idiot! \n ha haha ha ha ha haaa! \n ah hahaha haa! \n- 開発者一同、感謝を込めて"
   sp_event_YAAI_REMARK: "こんな物作る奴の方がバカだ！"
+
+  sp_event_DIS_North_America: "ディズニー=アメリカ大陸"
+  sp_event_DIS_North_America_QUOTE: "ディズニーは今日、「ディズニーランド」のグランドオープンを宣言した。海も、山も、川も、湖も全てがパークとなり、アメリカは巨大な舞台装置となった。もはや不可逆的な開発は、アメリカ大陸に何を齎すのだろうか……\n\nディズニー「Welcome!!!」"
+  sp_event_DIS_North_America_REMARK: "他国「まさに『ヒト科の』楽園だな」"


### PR DESCRIPTION
## Summary
- add a scripted trigger and on_action check so Disneyland fires a super event when it controls all of North America
- hook the new super event into the existing super news system, GUI, sprites, and localisation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690163935b848322be7f3092c6fcb6b2