### PR TITLE
fix(map-ide): Fix map rendering - WebGL2 with Canvas 2D fallback

### DIFF
--- a/map-ide/src/components/map/WebGLMapCanvas.tsx
+++ b/map-ide/src/components/map/WebGLMapCanvas.tsx
@@ -28,6 +28,8 @@ const WebGLMapCanvas: React.FC = () => {
     lastPos: null,
     lineStart: null,
   });
+  
+  const [rendererType, setRendererType] = useState<'webgl' | 'canvas2d' | 'none'>('none');
 
   // Map store state
   const bmpEditor = useMapStore((state) => state.bmpEditor);
@@ -78,8 +80,11 @@ const WebGLMapCanvas: React.FC = () => {
 
     try {
       rendererRef.current = new WebGLRenderer(canvas);
+      setRendererType(rendererRef.current.getRendererType());
+      console.log('Renderer initialized:', rendererRef.current.getRendererType());
     } catch (error) {
-      console.error('Failed to initialize WebGL renderer:', error);
+      console.error('Failed to initialize renderer:', error);
+      setRendererType('none');
     }
 
     return () => {
@@ -93,6 +98,7 @@ const WebGLMapCanvas: React.FC = () => {
     const renderer = rendererRef.current;
     if (!renderer || !bmpEditor) return;
 
+    console.log('Uploading map data:', bmpEditor.width, 'x', bmpEditor.height);
     renderer.uploadMapData(bmpEditor.pixels, bmpEditor.width, bmpEditor.height);
     
     // Fit to view after loading
@@ -439,6 +445,9 @@ const WebGLMapCanvas: React.FC = () => {
       <div className="absolute bottom-4 right-4 bg-ide-sidebar px-3 py-2 rounded-lg shadow-lg border border-ide-border">
         <div className="text-sm font-mono text-ide-text">
           {(zoom * 100).toFixed(0)}%
+        </div>
+        <div className="text-xs text-ide-text-muted mt-1">
+          {rendererType === 'webgl' ? '🎮 WebGL' : rendererType === 'canvas2d' ? '🖌️ Canvas' : '⏳'}
         </div>
       </div>
       

--- a/map-ide/src/core/WebGLRenderer.ts
+++ b/map-ide/src/core/WebGLRenderer.ts
@@ -1,116 +1,10 @@
 /**
- * WebGL2 Renderer for high-performance map rendering
- * Supports multiple overlay layers (provinces, states, strategic regions, AI areas)
+ * High-Performance Map Renderer
+ * Uses WebGL2 for GPU-accelerated rendering with Canvas 2D fallback
+ * Features: Smooth rendering, GPU texture caching, efficient updates
  */
 
 import { RGB, Province, State, StrategicRegion, AIArea } from '../types';
-
-// Shader source code
-const VERTEX_SHADER_SOURCE = `#version 300 es
-precision highp float;
-
-in vec2 a_position;
-in vec2 a_texCoord;
-
-out vec2 v_texCoord;
-
-uniform vec2 u_resolution;
-uniform vec2 u_translation;
-uniform float u_scale;
-
-void main() {
-    vec2 position = (a_position * u_scale + u_translation) / u_resolution * 2.0 - 1.0;
-    position.y = -position.y; // Flip Y for WebGL coordinate system
-    gl_Position = vec4(position, 0, 1);
-    v_texCoord = a_texCoord;
-}
-`;
-
-const FRAGMENT_SHADER_SOURCE = `#version 300 es
-precision highp float;
-
-in vec2 v_texCoord;
-out vec4 outColor;
-
-uniform sampler2D u_mapTexture;
-uniform sampler2D u_overlayTexture;
-uniform float u_overlayOpacity;
-uniform bool u_hasOverlay;
-uniform vec4 u_highlightColor;
-uniform bool u_hasHighlight;
-
-void main() {
-    vec4 mapColor = texture(u_mapTexture, v_texCoord);
-    
-    if (u_hasOverlay) {
-        vec4 overlayColor = texture(u_overlayTexture, v_texCoord);
-        if (overlayColor.a > 0.0) {
-            mapColor = mix(mapColor, overlayColor, overlayColor.a * u_overlayOpacity);
-        }
-    }
-    
-    if (u_hasHighlight && u_highlightColor.a > 0.0) {
-        mapColor = mix(mapColor, u_highlightColor, 0.3);
-    }
-    
-    outColor = mapColor;
-}
-`;
-
-// Border line shader
-const BORDER_VERTEX_SHADER = `#version 300 es
-precision highp float;
-
-in vec2 a_position;
-uniform vec2 u_resolution;
-uniform vec2 u_translation;
-uniform float u_scale;
-
-void main() {
-    vec2 position = (a_position * u_scale + u_translation) / u_resolution * 2.0 - 1.0;
-    position.y = -position.y;
-    gl_Position = vec4(position, 0, 1);
-}
-`;
-
-const BORDER_FRAGMENT_SHADER = `#version 300 es
-precision highp float;
-
-out vec4 outColor;
-uniform vec4 u_color;
-
-void main() {
-    outColor = u_color;
-}
-`;
-
-// Grid shader
-const GRID_VERTEX_SHADER = `#version 300 es
-precision highp float;
-
-in vec2 a_position;
-
-uniform vec2 u_resolution;
-uniform vec2 u_translation;
-uniform float u_scale;
-
-void main() {
-    vec2 position = (a_position * u_scale + u_translation) / u_resolution * 2.0 - 1.0;
-    position.y = -position.y;
-    gl_Position = vec4(position, 0, 1);
-}
-`;
-
-const GRID_FRAGMENT_SHADER = `#version 300 es
-precision highp float;
-
-out vec4 outColor;
-uniform vec4 u_gridColor;
-
-void main() {
-    outColor = u_gridColor;
-}
-`;
 
 export interface BorderSegment {
   points: Float32Array;
@@ -131,187 +25,306 @@ export interface RenderState {
   layerOpacity: number;
 }
 
+// Vertex shader for WebGL rendering
+const VERTEX_SHADER_SOURCE = `#version 300 es
+precision highp float;
+
+in vec2 a_position;
+in vec2 a_texCoord;
+
+uniform vec2 u_resolution;
+uniform vec2 u_translation;
+uniform float u_scale;
+
+out vec2 v_texCoord;
+
+void main() {
+  // Apply pan and zoom
+  vec2 scaled = a_position * u_scale;
+  vec2 translated = scaled + u_translation;
+  
+  // Convert to clip space (-1 to 1)
+  vec2 clipSpace = (translated / u_resolution) * 2.0 - 1.0;
+  
+  gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
+  v_texCoord = a_texCoord;
+}
+`;
+
+// Fragment shader for map rendering with smooth zoom
+const FRAGMENT_SHADER_SOURCE = `#version 300 es
+precision highp float;
+
+in vec2 v_texCoord;
+
+uniform sampler2D u_mapTexture;
+uniform sampler2D u_highlightTexture;
+uniform float u_zoom;
+uniform bool u_useSmoothing;
+
+out vec4 outColor;
+
+void main() {
+  // Get base map color
+  vec4 mapColor;
+  
+  if (u_useSmoothing && u_zoom < 4.0) {
+    // Use bilinear filtering for smoother rendering at low zoom
+    mapColor = texture(u_mapTexture, v_texCoord);
+  } else {
+    // Use nearest neighbor for pixel-perfect at high zoom
+    mapColor = texture(u_mapTexture, v_texCoord);
+  }
+  
+  // Get highlight overlay
+  vec4 highlight = texture(u_highlightTexture, v_texCoord);
+  
+  // Blend highlight over map
+  outColor = mix(mapColor, highlight, highlight.a);
+}
+`;
+
+// Vertex shader for border/grid lines
+const LINE_VERTEX_SHADER = `#version 300 es
+precision highp float;
+
+in vec2 a_position;
+
+uniform vec2 u_resolution;
+uniform vec2 u_translation;
+uniform float u_scale;
+
+void main() {
+  vec2 scaled = a_position * u_scale;
+  vec2 translated = scaled + u_translation;
+  vec2 clipSpace = (translated / u_resolution) * 2.0 - 1.0;
+  gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
+  gl_PointSize = 2.0;
+}
+`;
+
+// Fragment shader for lines
+const LINE_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+uniform vec4 u_color;
+out vec4 outColor;
+
+void main() {
+  outColor = u_color;
+}
+`;
+
+/**
+ * WebGL2 Renderer with Canvas 2D fallback
+ */
 export class WebGLRenderer {
   private canvas: HTMLCanvasElement;
-  private gl: WebGL2RenderingContext;
+  private gl: WebGL2RenderingContext | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private useWebGL: boolean = false;
   
-  // Main shader program
-  private mainProgram: WebGLProgram;
-  private mainVAO: WebGLVertexArrayObject;
-  private positionBuffer: WebGLBuffer;
-  private texCoordBuffer: WebGLBuffer;
-  
-  // Border shader program
-  private borderProgram: WebGLProgram;
-  private borderVAO: WebGLVertexArrayObject;
-  private borderBuffer: WebGLBuffer;
-  
-  // Grid shader program
-  private gridProgram: WebGLProgram;
-  private gridVAO: WebGLVertexArrayObject;
-  private gridBuffer: WebGLBuffer;
-  
-  // Textures
-  private mapTexture: WebGLTexture;
-  private overlayTexture: WebGLTexture;
-  
-  // Map dimensions
+  // Map data
   private mapWidth: number = 0;
   private mapHeight: number = 0;
+  private provincePixelData: Uint8Array | null = null;
+  
+  // WebGL resources
+  private mapProgram: WebGLProgram | null = null;
+  private lineProgram: WebGLProgram | null = null;
+  private mapTexture: WebGLTexture | null = null;
+  private highlightTexture: WebGLTexture | null = null;
+  private quadVAO: WebGLVertexArrayObject | null = null;
+  private quadBuffer: WebGLBuffer | null = null;
+  private texCoordBuffer: WebGLBuffer | null = null;
+  private lineVAO: WebGLVertexArrayObject | null = null;
+  private lineBuffer: WebGLBuffer | null = null;
+  
+  // Canvas 2D fallback resources
+  private mapImageData: ImageData | null = null;
+  private highlightImageData: ImageData | null = null;
+  private offscreenCanvas: OffscreenCanvas | null = null;
+  private offscreenCtx: OffscreenCanvasRenderingContext2D | null = null;
   
   // Cached border data
   private stateBorders: Map<number, BorderSegment> = new Map();
   private strategicRegionBorders: Map<number, BorderSegment> = new Map();
   private aiAreaBorders: Map<string, BorderSegment> = new Map();
   
-  // Province pixel lookup (for selection highlighting)
-  private provincePixelData: Uint8Array | null = null;
-  private highlightMask: Uint8Array | null = null;
+  // Selection state
+  private selectedProvince: Province | null = null;
+  private hoveredProvince: Province | null = null;
+  private highlightDirty: boolean = true;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
     
+    // Try WebGL2 first
     const gl = canvas.getContext('webgl2', {
       alpha: false,
-      antialias: false,
-      preserveDrawingBuffer: true,
+      antialias: true,
       powerPreference: 'high-performance',
-    });
+      preserveDrawingBuffer: false,
+    }) as WebGL2RenderingContext | null;
     
-    if (!gl) {
-      throw new Error('WebGL2 is not supported');
+    if (gl) {
+      this.gl = gl;
+      this.useWebGL = true;
+      this.initWebGL();
+      console.log('WebGL2 renderer initialized');
+    } else {
+      // Fallback to Canvas 2D
+      const ctx = canvas.getContext('2d', {
+        alpha: false,
+        desynchronized: true,
+      });
+      
+      if (!ctx) {
+        throw new Error('Neither WebGL2 nor Canvas 2D context is available');
+      }
+      
+      this.ctx = ctx;
+      this.useWebGL = false;
+      console.log('Canvas 2D fallback renderer initialized');
+    }
+  }
+
+  /**
+   * Initialize WebGL2 resources
+   */
+  private initWebGL(): void {
+    const gl = this.gl!;
+    
+    // Create shaders and programs
+    this.mapProgram = this.createProgram(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
+    this.lineProgram = this.createProgram(LINE_VERTEX_SHADER, LINE_FRAGMENT_SHADER);
+    
+    if (!this.mapProgram || !this.lineProgram) {
+      console.warn('Failed to create shaders, falling back to Canvas 2D');
+      this.useWebGL = false;
+      this.ctx = this.canvas.getContext('2d');
+      return;
     }
     
-    this.gl = gl;
+    // Create quad geometry for map rendering
+    this.createQuadVAO();
     
-    // Create shader programs
-    this.mainProgram = this.createProgram(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE);
-    this.borderProgram = this.createProgram(BORDER_VERTEX_SHADER, BORDER_FRAGMENT_SHADER);
-    this.gridProgram = this.createProgram(GRID_VERTEX_SHADER, GRID_FRAGMENT_SHADER);
-    
-    // Create VAOs and buffers
-    this.mainVAO = this.createMainVAO();
-    this.positionBuffer = gl.createBuffer()!;
-    this.texCoordBuffer = gl.createBuffer()!;
-    
-    this.borderVAO = gl.createVertexArray()!;
-    this.borderBuffer = gl.createBuffer()!;
-    this.setupBorderVAO();
-    
-    this.gridVAO = gl.createVertexArray()!;
-    this.gridBuffer = gl.createBuffer()!;
-    this.setupGridVAO();
+    // Create line VAO
+    this.createLineVAO();
     
     // Create textures
     this.mapTexture = this.createTexture();
-    this.overlayTexture = this.createTexture();
+    this.highlightTexture = this.createTexture();
     
     // Enable blending
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
   }
 
-  private createShader(type: number, source: string): WebGLShader {
-    const { gl } = this;
-    const shader = gl.createShader(type)!;
-    gl.shaderSource(shader, source);
-    gl.compileShader(shader);
+  private createProgram(vertexSource: string, fragmentSource: string): WebGLProgram | null {
+    const gl = this.gl!;
     
-    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-      const error = gl.getShaderInfoLog(shader);
-      gl.deleteShader(shader);
-      throw new Error(`Shader compilation failed: ${error}`);
+    const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    
+    if (!vertexShader || !fragmentShader) return null;
+    
+    gl.shaderSource(vertexShader, vertexSource);
+    gl.compileShader(vertexShader);
+    
+    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+      console.error('Vertex shader error:', gl.getShaderInfoLog(vertexShader));
+      return null;
     }
     
-    return shader;
-  }
-
-  private createProgram(vertexSource: string, fragmentSource: string): WebGLProgram {
-    const { gl } = this;
-    const vertexShader = this.createShader(gl.VERTEX_SHADER, vertexSource);
-    const fragmentShader = this.createShader(gl.FRAGMENT_SHADER, fragmentSource);
+    gl.shaderSource(fragmentShader, fragmentSource);
+    gl.compileShader(fragmentShader);
     
-    const program = gl.createProgram()!;
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+      console.error('Fragment shader error:', gl.getShaderInfoLog(fragmentShader));
+      return null;
+    }
+    
+    const program = gl.createProgram();
+    if (!program) return null;
+    
     gl.attachShader(program, vertexShader);
     gl.attachShader(program, fragmentShader);
     gl.linkProgram(program);
     
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-      const error = gl.getProgramInfoLog(program);
-      gl.deleteProgram(program);
-      throw new Error(`Program linking failed: ${error}`);
+      console.error('Program link error:', gl.getProgramInfoLog(program));
+      return null;
     }
     
+    // Clean up shaders
     gl.deleteShader(vertexShader);
     gl.deleteShader(fragmentShader);
     
     return program;
   }
 
-  private createMainVAO(): WebGLVertexArrayObject {
-    const { gl } = this;
-    const vao = gl.createVertexArray()!;
+  private createQuadVAO(): void {
+    const gl = this.gl!;
     
-    // Create buffers first
-    this.positionBuffer = gl.createBuffer()!;
-    this.texCoordBuffer = gl.createBuffer()!;
+    // Create VAO
+    this.quadVAO = gl.createVertexArray();
+    gl.bindVertexArray(this.quadVAO);
     
-    // Initialize buffers with empty data
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(12), gl.DYNAMIC_DRAW);
+    // Create position buffer - will be updated when map is loaded
+    this.quadBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.quadBuffer);
     
+    // Get attribute location
+    const posLoc = gl.getAttribLocation(this.mapProgram!, 'a_position');
+    gl.enableVertexAttribArray(posLoc);
+    gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+    
+    // Create texCoord buffer
+    this.texCoordBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(12), gl.DYNAMIC_DRAW);
     
-    // Now setup VAO
-    gl.bindVertexArray(vao);
+    // Texture coordinates (standard UV mapping)
+    const texCoords = new Float32Array([
+      0, 0,  // top-left
+      1, 0,  // top-right
+      0, 1,  // bottom-left
+      0, 1,  // bottom-left
+      1, 0,  // top-right
+      1, 1,  // bottom-right
+    ]);
+    gl.bufferData(gl.ARRAY_BUFFER, texCoords, gl.STATIC_DRAW);
     
-    // Position attribute
-    const positionLocation = gl.getAttribLocation(this.mainProgram, 'a_position');
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.enableVertexAttribArray(positionLocation);
-    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
-    
-    // Texture coordinate attribute
-    const texCoordLocation = gl.getAttribLocation(this.mainProgram, 'a_texCoord');
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.enableVertexAttribArray(texCoordLocation);
-    gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
-    
-    gl.bindVertexArray(null);
-    return vao;
-  }
-
-  private setupBorderVAO(): void {
-    const { gl } = this;
-    gl.bindVertexArray(this.borderVAO);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.borderBuffer);
-    
-    const positionLocation = gl.getAttribLocation(this.borderProgram, 'a_position');
-    gl.enableVertexAttribArray(positionLocation);
-    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+    const texLoc = gl.getAttribLocation(this.mapProgram!, 'a_texCoord');
+    gl.enableVertexAttribArray(texLoc);
+    gl.vertexAttribPointer(texLoc, 2, gl.FLOAT, false, 0, 0);
     
     gl.bindVertexArray(null);
   }
 
-  private setupGridVAO(): void {
-    const { gl } = this;
-    gl.bindVertexArray(this.gridVAO);
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.gridBuffer);
+  private createLineVAO(): void {
+    const gl = this.gl!;
     
-    const positionLocation = gl.getAttribLocation(this.gridProgram, 'a_position');
-    gl.enableVertexAttribArray(positionLocation);
-    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+    this.lineVAO = gl.createVertexArray();
+    gl.bindVertexArray(this.lineVAO);
+    
+    this.lineBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.lineBuffer);
+    
+    const posLoc = gl.getAttribLocation(this.lineProgram!, 'a_position');
+    gl.enableVertexAttribArray(posLoc);
+    gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
     
     gl.bindVertexArray(null);
   }
 
-  private createTexture(): WebGLTexture {
-    const { gl } = this;
-    const texture = gl.createTexture()!;
+  private createTexture(): WebGLTexture | null {
+    const gl = this.gl!;
+    
+    const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
     
-    // Set texture parameters for pixel-perfect rendering
+    // Set texture parameters - NEAREST for pixel-perfect at high zoom
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
@@ -321,85 +334,85 @@ export class WebGLRenderer {
   }
 
   /**
-   * Upload map pixel data to GPU texture
+   * Upload map pixel data
    */
   uploadMapData(pixels: Uint8Array, width: number, height: number): void {
-    const { gl } = this;
-    
     this.mapWidth = width;
     this.mapHeight = height;
     this.provincePixelData = new Uint8Array(pixels);
     
-    // Convert RGB to RGBA
+    if (this.useWebGL && this.gl) {
+      this.uploadMapTextureWebGL(pixels, width, height);
+      this.updateQuadBuffer();
+    } else {
+      this.createMapImageData(pixels, width, height);
+    }
+    
+    // Create offscreen canvas for highlight overlay
+    this.offscreenCanvas = new OffscreenCanvas(width, height);
+    this.offscreenCtx = this.offscreenCanvas.getContext('2d');
+    
+    this.highlightDirty = true;
+  }
+
+  private uploadMapTextureWebGL(pixels: Uint8Array, width: number, height: number): void {
+    const gl = this.gl!;
+    
+    // Convert RGB to RGBA for WebGL
     const rgbaData = new Uint8Array(width * height * 4);
     for (let i = 0; i < width * height; i++) {
-      rgbaData[i * 4] = pixels[i * 3];
-      rgbaData[i * 4 + 1] = pixels[i * 3 + 1];
-      rgbaData[i * 4 + 2] = pixels[i * 3 + 2];
-      rgbaData[i * 4 + 3] = 255;
+      rgbaData[i * 4] = pixels[i * 3];       // R
+      rgbaData[i * 4 + 1] = pixels[i * 3 + 1]; // G
+      rgbaData[i * 4 + 2] = pixels[i * 3 + 2]; // B
+      rgbaData[i * 4 + 3] = 255;             // A
     }
     
     gl.bindTexture(gl.TEXTURE_2D, this.mapTexture);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, rgbaData);
+  }
+
+  private updateQuadBuffer(): void {
+    const gl = this.gl!;
     
-    // Initialize highlight mask
-    this.highlightMask = new Uint8Array(width * height * 4);
+    // Create quad covering the map dimensions
+    const positions = new Float32Array([
+      0, 0,                           // top-left
+      this.mapWidth, 0,               // top-right
+      0, this.mapHeight,              // bottom-left
+      0, this.mapHeight,              // bottom-left
+      this.mapWidth, 0,               // top-right
+      this.mapWidth, this.mapHeight,  // bottom-right
+    ]);
     
-    // Update quad vertices
-    this.updateQuadVertices();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.quadBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+  }
+
+  private createMapImageData(pixels: Uint8Array, width: number, height: number): void {
+    this.mapImageData = new ImageData(width, height);
+    const data = this.mapImageData.data;
+    
+    for (let i = 0; i < width * height; i++) {
+      data[i * 4] = pixels[i * 3];       // R
+      data[i * 4 + 1] = pixels[i * 3 + 1]; // G
+      data[i * 4 + 2] = pixels[i * 3 + 2]; // B
+      data[i * 4 + 3] = 255;             // A
+    }
   }
 
   /**
    * Update map texture from modified pixel data
    */
   updateMapTexture(pixels: Uint8Array): void {
-    const { gl } = this;
-    
     if (!this.mapWidth || !this.mapHeight) return;
     
     this.provincePixelData = new Uint8Array(pixels);
     
-    // Convert RGB to RGBA
-    const rgbaData = new Uint8Array(this.mapWidth * this.mapHeight * 4);
-    for (let i = 0; i < this.mapWidth * this.mapHeight; i++) {
-      rgbaData[i * 4] = pixels[i * 3];
-      rgbaData[i * 4 + 1] = pixels[i * 3 + 1];
-      rgbaData[i * 4 + 2] = pixels[i * 3 + 2];
-      rgbaData[i * 4 + 3] = 255;
+    if (this.useWebGL && this.gl) {
+      this.uploadMapTextureWebGL(pixels, this.mapWidth, this.mapHeight);
+    } else {
+      this.createMapImageData(pixels, this.mapWidth, this.mapHeight);
     }
-    
-    gl.bindTexture(gl.TEXTURE_2D, this.mapTexture);
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, this.mapWidth, this.mapHeight, gl.RGBA, gl.UNSIGNED_BYTE, rgbaData);
-  }
-
-  private updateQuadVertices(): void {
-    const { gl } = this;
-    
-    // Position vertices (full quad - two triangles)
-    const positions = new Float32Array([
-      0, 0,
-      this.mapWidth, 0,
-      0, this.mapHeight,
-      0, this.mapHeight,
-      this.mapWidth, 0,
-      this.mapWidth, this.mapHeight,
-    ]);
-    
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
-    
-    // Texture coordinates (matching position order)
-    const texCoords = new Float32Array([
-      0, 0,  // top-left
-      1, 0,  // top-right
-      0, 1,  // bottom-left
-      0, 1,  // bottom-left
-      1, 0,  // top-right
-      1, 1,  // bottom-right
-    ]);
-    
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.texCoordBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, texCoords, gl.STATIC_DRAW);
   }
 
   /**
@@ -407,12 +420,11 @@ export class WebGLRenderer {
    */
   generateStateBorders(
     states: Map<number, State>,
-    provinces: Map<number, Province>,
+    _provinces: Map<number, Province>,
     provinceByColor: Map<string, Province>
   ): void {
     this.stateBorders.clear();
     
-    // Create province to state mapping
     const provinceToState = new Map<number, number>();
     for (const [stateId, state] of states) {
       for (const provinceId of state.provinces) {
@@ -420,16 +432,13 @@ export class WebGLRenderer {
       }
     }
     
-    // Generate borders by detecting state boundaries in pixel data
     if (!this.provincePixelData) return;
     
     const borderPixels = this.detectBorders(
-      provinces,
       provinceByColor,
       (p1, p2) => provinceToState.get(p1?.id ?? -1) !== provinceToState.get(p2?.id ?? -1)
     );
     
-    // Group by state and create border segments
     for (const [stateId, state] of states) {
       const stateProvinces = new Set(state.provinces);
       const points: number[] = [];
@@ -446,7 +455,7 @@ export class WebGLRenderer {
       if (points.length > 0) {
         this.stateBorders.set(stateId, {
           points: new Float32Array(points),
-          color: [1.0, 0.8, 0.0, 0.8], // Yellow for state borders
+          color: [1.0, 0.8, 0.0, 0.8], // Orange
         });
       }
     }
@@ -457,12 +466,11 @@ export class WebGLRenderer {
    */
   generateStrategicRegionBorders(
     regions: Map<number, StrategicRegion>,
-    provinces: Map<number, Province>,
+    _provinces: Map<number, Province>,
     provinceByColor: Map<string, Province>
   ): void {
     this.strategicRegionBorders.clear();
     
-    // Create province to region mapping
     const provinceToRegion = new Map<number, number>();
     for (const [regionId, region] of regions) {
       for (const provinceId of region.provinces) {
@@ -473,7 +481,6 @@ export class WebGLRenderer {
     if (!this.provincePixelData) return;
     
     const borderPixels = this.detectBorders(
-      provinces,
       provinceByColor,
       (p1, p2) => provinceToRegion.get(p1?.id ?? -1) !== provinceToRegion.get(p2?.id ?? -1)
     );
@@ -494,7 +501,7 @@ export class WebGLRenderer {
       if (points.length > 0) {
         this.strategicRegionBorders.set(regionId, {
           points: new Float32Array(points),
-          color: [0.0, 0.8, 1.0, 0.8], // Cyan for strategic region borders
+          color: [0.0, 0.8, 1.0, 0.8], // Cyan
         });
       }
     }
@@ -506,12 +513,11 @@ export class WebGLRenderer {
   generateAIAreaBorders(
     aiAreas: AIArea[],
     regions: Map<number, StrategicRegion>,
-    provinces: Map<number, Province>,
+    _provinces: Map<number, Province>,
     provinceByColor: Map<string, Province>
   ): void {
     this.aiAreaBorders.clear();
     
-    // Build province to AI area mapping
     const provinceToArea = new Map<number, string>();
     for (const area of aiAreas) {
       if (area.strategicRegions) {
@@ -529,7 +535,6 @@ export class WebGLRenderer {
     if (!this.provincePixelData) return;
     
     const borderPixels = this.detectBorders(
-      provinces,
       provinceByColor,
       (p1, p2) => provinceToArea.get(p1?.id ?? -1) !== provinceToArea.get(p2?.id ?? -1)
     );
@@ -560,14 +565,13 @@ export class WebGLRenderer {
       if (points.length > 0) {
         this.aiAreaBorders.set(area.name, {
           points: new Float32Array(points),
-          color: [1.0, 0.0, 0.8, 0.8], // Magenta for AI area borders
+          color: [1.0, 0.0, 0.8, 0.8], // Magenta
         });
       }
     }
   }
 
   private detectBorders(
-    _provinces: Map<number, Province>,
     provinceByColor: Map<string, Province>,
     isBoundary: (p1: Province | undefined, p2: Province | undefined) => boolean
   ): [number, number][] {
@@ -577,8 +581,6 @@ export class WebGLRenderer {
     
     const width = this.mapWidth;
     const height = this.mapHeight;
-    
-    // Sample at lower resolution for performance
     const step = Math.max(1, Math.floor(width / 1024));
     
     for (let y = 0; y < height - 1; y += step) {
@@ -616,139 +618,159 @@ export class WebGLRenderer {
   }
 
   /**
-   * Create highlight overlay for selected/hovered province
+   * Update highlight overlay for selected/hovered province
    */
   updateHighlightOverlay(
     selectedProvinceId: number | null,
     hoveredProvinceId: number | null,
     provinces: Map<number, Province>
   ): void {
-    const { gl } = this;
+    const newSelected = selectedProvinceId ? provinces.get(selectedProvinceId) || null : null;
+    const newHovered = hoveredProvinceId ? provinces.get(hoveredProvinceId) || null : null;
     
-    if (!this.highlightMask || !this.provincePixelData) return;
+    if (this.selectedProvince !== newSelected || this.hoveredProvince !== newHovered) {
+      this.selectedProvince = newSelected;
+      this.hoveredProvince = newHovered;
+      this.highlightDirty = true;
+    }
+  }
+
+  private updateHighlightTexture(): void {
+    if (!this.highlightDirty || !this.provincePixelData) return;
     
-    // Clear highlight mask
-    this.highlightMask.fill(0);
+    const width = this.mapWidth;
+    const height = this.mapHeight;
     
-    const selectedProvince = selectedProvinceId ? provinces.get(selectedProvinceId) : null;
-    const hoveredProvince = hoveredProvinceId ? provinces.get(hoveredProvinceId) : null;
+    // Create highlight data
+    const highlightData = new Uint8Array(width * height * 4);
     
-    // Apply highlights
-    for (let i = 0; i < this.mapWidth * this.mapHeight; i++) {
+    for (let i = 0; i < width * height; i++) {
       const r = this.provincePixelData[i * 3];
       const g = this.provincePixelData[i * 3 + 1];
       const b = this.provincePixelData[i * 3 + 2];
       
-      if (selectedProvince && 
-          r === selectedProvince.color.r &&
-          g === selectedProvince.color.g &&
-          b === selectedProvince.color.b) {
+      if (this.selectedProvince &&
+          r === this.selectedProvince.color.r &&
+          g === this.selectedProvince.color.g &&
+          b === this.selectedProvince.color.b) {
         // Yellow highlight for selected
-        this.highlightMask[i * 4] = 255;
-        this.highlightMask[i * 4 + 1] = 200;
-        this.highlightMask[i * 4 + 2] = 0;
-        this.highlightMask[i * 4 + 3] = 128;
-      } else if (hoveredProvince && 
-                 r === hoveredProvince.color.r &&
-                 g === hoveredProvince.color.g &&
-                 b === hoveredProvince.color.b) {
+        highlightData[i * 4] = 255;
+        highlightData[i * 4 + 1] = 200;
+        highlightData[i * 4 + 2] = 0;
+        highlightData[i * 4 + 3] = 100;
+      } else if (this.hoveredProvince &&
+                 r === this.hoveredProvince.color.r &&
+                 g === this.hoveredProvince.color.g &&
+                 b === this.hoveredProvince.color.b) {
         // Light blue highlight for hovered
-        this.highlightMask[i * 4] = 100;
-        this.highlightMask[i * 4 + 1] = 200;
-        this.highlightMask[i * 4 + 2] = 255;
-        this.highlightMask[i * 4 + 3] = 80;
+        highlightData[i * 4] = 100;
+        highlightData[i * 4 + 1] = 200;
+        highlightData[i * 4 + 2] = 255;
+        highlightData[i * 4 + 3] = 60;
+      } else {
+        highlightData[i * 4 + 3] = 0; // Transparent
       }
     }
     
-    // Upload to texture
-    gl.bindTexture(gl.TEXTURE_2D, this.overlayTexture);
-    gl.texImage2D(
-      gl.TEXTURE_2D, 0, gl.RGBA,
-      this.mapWidth, this.mapHeight, 0,
-      gl.RGBA, gl.UNSIGNED_BYTE, this.highlightMask
-    );
+    if (this.useWebGL && this.gl) {
+      const gl = this.gl;
+      gl.bindTexture(gl.TEXTURE_2D, this.highlightTexture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, highlightData);
+    } else if (this.offscreenCtx) {
+      this.highlightImageData = new ImageData(new Uint8ClampedArray(highlightData), width, height);
+    }
+    
+    this.highlightDirty = false;
   }
 
   /**
-   * Render the map with all overlays
+   * Main render function
    */
   render(state: RenderState): void {
-    const { gl } = this;
-    
     // Resize canvas if needed
     if (this.canvas.width !== state.viewportWidth || this.canvas.height !== state.viewportHeight) {
       this.canvas.width = state.viewportWidth;
       this.canvas.height = state.viewportHeight;
-      gl.viewport(0, 0, state.viewportWidth, state.viewportHeight);
     }
     
-    // Clear canvas
+    // Update highlight texture if dirty
+    this.updateHighlightTexture();
+    
+    if (this.useWebGL && this.gl) {
+      this.renderWebGL(state);
+    } else if (this.ctx) {
+      this.renderCanvas2D(state);
+    }
+  }
+
+  private renderWebGL(state: RenderState): void {
+    const gl = this.gl!;
+    
+    // Set viewport
+    gl.viewport(0, 0, state.viewportWidth, state.viewportHeight);
+    
+    // Clear with dark background
     gl.clearColor(0.12, 0.12, 0.12, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     
-    if (!this.mapWidth || !this.mapHeight) return;
+    if (!this.mapWidth || !this.mapHeight || !this.mapProgram) return;
     
-    // Render main map
-    gl.useProgram(this.mainProgram);
-    gl.bindVertexArray(this.mainVAO);
+    // Use map program
+    gl.useProgram(this.mapProgram);
     
     // Set uniforms
-    const resolutionLocation = gl.getUniformLocation(this.mainProgram, 'u_resolution');
-    const translationLocation = gl.getUniformLocation(this.mainProgram, 'u_translation');
-    const scaleLocation = gl.getUniformLocation(this.mainProgram, 'u_scale');
-    const mapTextureLocation = gl.getUniformLocation(this.mainProgram, 'u_mapTexture');
-    const overlayTextureLocation = gl.getUniformLocation(this.mainProgram, 'u_overlayTexture');
-    const overlayOpacityLocation = gl.getUniformLocation(this.mainProgram, 'u_overlayOpacity');
-    const hasOverlayLocation = gl.getUniformLocation(this.mainProgram, 'u_hasOverlay');
+    const resLoc = gl.getUniformLocation(this.mapProgram, 'u_resolution');
+    const transLoc = gl.getUniformLocation(this.mapProgram, 'u_translation');
+    const scaleLoc = gl.getUniformLocation(this.mapProgram, 'u_scale');
+    const zoomLoc = gl.getUniformLocation(this.mapProgram, 'u_zoom');
+    const smoothLoc = gl.getUniformLocation(this.mapProgram, 'u_useSmoothing');
+    const mapTexLoc = gl.getUniformLocation(this.mapProgram, 'u_mapTexture');
+    const highlightTexLoc = gl.getUniformLocation(this.mapProgram, 'u_highlightTexture');
     
-    gl.uniform2f(resolutionLocation, state.viewportWidth, state.viewportHeight);
-    gl.uniform2f(translationLocation, state.panX, state.panY);
-    gl.uniform1f(scaleLocation, state.zoom);
+    gl.uniform2f(resLoc, state.viewportWidth, state.viewportHeight);
+    gl.uniform2f(transLoc, state.panX, state.panY);
+    gl.uniform1f(scaleLoc, state.zoom);
+    gl.uniform1f(zoomLoc, state.zoom);
+    gl.uniform1i(smoothLoc, state.zoom < 4 ? 1 : 0);
     
     // Bind textures
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.mapTexture);
-    gl.uniform1i(mapTextureLocation, 0);
+    gl.uniform1i(mapTexLoc, 0);
     
     gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, this.overlayTexture);
-    gl.uniform1i(overlayTextureLocation, 1);
+    gl.bindTexture(gl.TEXTURE_2D, this.highlightTexture);
+    gl.uniform1i(highlightTexLoc, 1);
     
-    gl.uniform1f(overlayOpacityLocation, state.layerOpacity);
-    gl.uniform1i(hasOverlayLocation, 
-      state.selectedProvinceId !== null || state.hoveredProvinceId !== null ? 1 : 0
-    );
+    // Update texture filtering based on zoom
+    gl.bindTexture(gl.TEXTURE_2D, this.mapTexture);
+    if (state.zoom >= 4) {
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    } else {
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    }
     
-    // Draw map quad
+    // Draw map
+    gl.bindVertexArray(this.quadVAO);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     
-    // Render borders based on active layer
+    // Draw borders
     if (state.showBorders) {
-      this.renderBorders(state);
+      this.renderBordersWebGL(state);
     }
     
-    // Render grid at high zoom
+    // Draw grid at high zoom
     if (state.showGrid && state.zoom >= 8) {
-      this.renderGrid(state);
+      this.renderGridWebGL(state);
     }
-    
-    gl.bindVertexArray(null);
   }
 
-  private renderBorders(state: RenderState): void {
-    const { gl } = this;
+  private renderBordersWebGL(state: RenderState): void {
+    const gl = this.gl!;
     
-    gl.useProgram(this.borderProgram);
-    gl.bindVertexArray(this.borderVAO);
-    
-    const resolutionLocation = gl.getUniformLocation(this.borderProgram, 'u_resolution');
-    const translationLocation = gl.getUniformLocation(this.borderProgram, 'u_translation');
-    const scaleLocation = gl.getUniformLocation(this.borderProgram, 'u_scale');
-    const colorLocation = gl.getUniformLocation(this.borderProgram, 'u_color');
-    
-    gl.uniform2f(resolutionLocation, state.viewportWidth, state.viewportHeight);
-    gl.uniform2f(translationLocation, state.panX, state.panY);
-    gl.uniform1f(scaleLocation, state.zoom);
+    if (!this.lineProgram) return;
     
     let borders: Map<number | string, BorderSegment>;
     
@@ -766,31 +788,33 @@ export class WebGLRenderer {
         return;
     }
     
+    gl.useProgram(this.lineProgram);
+    
+    const resLoc = gl.getUniformLocation(this.lineProgram, 'u_resolution');
+    const transLoc = gl.getUniformLocation(this.lineProgram, 'u_translation');
+    const scaleLoc = gl.getUniformLocation(this.lineProgram, 'u_scale');
+    const colorLoc = gl.getUniformLocation(this.lineProgram, 'u_color');
+    
+    gl.uniform2f(resLoc, state.viewportWidth, state.viewportHeight);
+    gl.uniform2f(transLoc, state.panX, state.panY);
+    gl.uniform1f(scaleLoc, state.zoom);
+    
+    gl.bindVertexArray(this.lineVAO);
+    
     for (const [, segment] of borders) {
-      gl.uniform4fv(colorLocation, segment.color);
-      gl.bindBuffer(gl.ARRAY_BUFFER, this.borderBuffer);
+      gl.uniform4fv(colorLoc, segment.color);
+      
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.lineBuffer);
       gl.bufferData(gl.ARRAY_BUFFER, segment.points, gl.DYNAMIC_DRAW);
+      
       gl.drawArrays(gl.POINTS, 0, segment.points.length / 2);
     }
-    
-    gl.bindVertexArray(null);
   }
 
-  private renderGrid(state: RenderState): void {
-    const { gl } = this;
+  private renderGridWebGL(state: RenderState): void {
+    const gl = this.gl!;
     
-    gl.useProgram(this.gridProgram);
-    gl.bindVertexArray(this.gridVAO);
-    
-    const resolutionLocation = gl.getUniformLocation(this.gridProgram, 'u_resolution');
-    const translationLocation = gl.getUniformLocation(this.gridProgram, 'u_translation');
-    const scaleLocation = gl.getUniformLocation(this.gridProgram, 'u_scale');
-    const gridColorLocation = gl.getUniformLocation(this.gridProgram, 'u_gridColor');
-    
-    gl.uniform2f(resolutionLocation, state.viewportWidth, state.viewportHeight);
-    gl.uniform2f(translationLocation, state.panX, state.panY);
-    gl.uniform1f(scaleLocation, state.zoom);
-    gl.uniform4f(gridColorLocation, 0.4, 0.4, 0.4, 0.3);
+    if (!this.lineProgram) return;
     
     // Calculate visible area
     const startX = Math.max(0, Math.floor(-state.panX / state.zoom));
@@ -799,20 +823,162 @@ export class WebGLRenderer {
     const endY = Math.min(this.mapHeight, Math.ceil((state.viewportHeight - state.panY) / state.zoom));
     
     // Generate grid lines
-    const gridLines: number[] = [];
+    const gridPoints: number[] = [];
     
+    // Vertical lines
     for (let x = startX; x <= endX; x++) {
-      gridLines.push(x, startY, x, endY);
+      gridPoints.push(x, startY, x, endY);
     }
+    
+    // Horizontal lines
     for (let y = startY; y <= endY; y++) {
-      gridLines.push(startX, y, endX, y);
+      gridPoints.push(startX, y, endX, y);
     }
     
-    gl.bindBuffer(gl.ARRAY_BUFFER, this.gridBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(gridLines), gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, gridLines.length / 2);
+    if (gridPoints.length === 0) return;
     
-    gl.bindVertexArray(null);
+    gl.useProgram(this.lineProgram);
+    
+    const resLoc = gl.getUniformLocation(this.lineProgram, 'u_resolution');
+    const transLoc = gl.getUniformLocation(this.lineProgram, 'u_translation');
+    const scaleLoc = gl.getUniformLocation(this.lineProgram, 'u_scale');
+    const colorLoc = gl.getUniformLocation(this.lineProgram, 'u_color');
+    
+    gl.uniform2f(resLoc, state.viewportWidth, state.viewportHeight);
+    gl.uniform2f(transLoc, state.panX, state.panY);
+    gl.uniform1f(scaleLoc, state.zoom);
+    gl.uniform4f(colorLoc, 0.4, 0.4, 0.4, 0.3);
+    
+    gl.bindVertexArray(this.lineVAO);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.lineBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(gridPoints), gl.DYNAMIC_DRAW);
+    
+    gl.drawArrays(gl.LINES, 0, gridPoints.length / 2);
+  }
+
+  private renderCanvas2D(state: RenderState): void {
+    const ctx = this.ctx!;
+    
+    // Disable smoothing for pixel-perfect at high zoom
+    ctx.imageSmoothingEnabled = state.zoom < 4;
+    ctx.imageSmoothingQuality = 'high';
+    
+    // Clear canvas with dark background
+    ctx.fillStyle = '#1e1e1e';
+    ctx.fillRect(0, 0, state.viewportWidth, state.viewportHeight);
+    
+    if (!this.mapWidth || !this.mapHeight || !this.mapImageData) return;
+    
+    // Save context state
+    ctx.save();
+    
+    // Apply pan and zoom transformation
+    ctx.translate(state.panX, state.panY);
+    ctx.scale(state.zoom, state.zoom);
+    
+    // Draw map
+    this.renderMapCanvas2D(ctx);
+    
+    // Draw selection highlights
+    this.renderHighlightsCanvas2D(ctx);
+    
+    // Draw borders
+    if (state.showBorders) {
+      this.renderBordersCanvas2D(ctx, state);
+    }
+    
+    // Draw grid at high zoom
+    if (state.showGrid && state.zoom >= 8) {
+      this.renderGridCanvas2D(ctx, state);
+    }
+    
+    // Restore context state
+    ctx.restore();
+  }
+
+  private renderMapCanvas2D(ctx: CanvasRenderingContext2D): void {
+    if (!this.mapImageData) return;
+    
+    // Use offscreen canvas for better performance
+    if (!this.offscreenCanvas || !this.offscreenCtx) {
+      this.offscreenCanvas = new OffscreenCanvas(this.mapWidth, this.mapHeight);
+      this.offscreenCtx = this.offscreenCanvas.getContext('2d');
+    }
+    
+    if (this.offscreenCtx) {
+      this.offscreenCtx.putImageData(this.mapImageData, 0, 0);
+      ctx.drawImage(this.offscreenCanvas, 0, 0);
+    }
+  }
+
+  private renderHighlightsCanvas2D(ctx: CanvasRenderingContext2D): void {
+    if (!this.highlightImageData || !this.offscreenCtx) return;
+    
+    // Create temporary canvas for highlight
+    const highlightCanvas = new OffscreenCanvas(this.mapWidth, this.mapHeight);
+    const hCtx = highlightCanvas.getContext('2d');
+    
+    if (hCtx) {
+      hCtx.putImageData(this.highlightImageData, 0, 0);
+      ctx.globalCompositeOperation = 'source-over';
+      ctx.drawImage(highlightCanvas, 0, 0);
+    }
+  }
+
+  private renderBordersCanvas2D(ctx: CanvasRenderingContext2D, state: RenderState): void {
+    let borders: Map<number | string, BorderSegment>;
+    
+    switch (state.activeLayer) {
+      case 'states':
+        borders = this.stateBorders as Map<number | string, BorderSegment>;
+        break;
+      case 'strategicRegions':
+        borders = this.strategicRegionBorders as Map<number | string, BorderSegment>;
+        break;
+      case 'aiAreas':
+        borders = this.aiAreaBorders;
+        break;
+      default:
+        return;
+    }
+    
+    const pointSize = Math.max(1, 2 / state.zoom);
+    
+    for (const [, segment] of borders) {
+      const [r, g, b, a] = segment.color;
+      ctx.fillStyle = `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
+      
+      const points = segment.points;
+      for (let i = 0; i < points.length; i += 2) {
+        ctx.fillRect(points[i], points[i + 1], pointSize, pointSize);
+      }
+    }
+  }
+
+  private renderGridCanvas2D(ctx: CanvasRenderingContext2D, state: RenderState): void {
+    const startX = Math.max(0, Math.floor(-state.panX / state.zoom));
+    const startY = Math.max(0, Math.floor(-state.panY / state.zoom));
+    const endX = Math.min(this.mapWidth, Math.ceil((state.viewportWidth - state.panX) / state.zoom));
+    const endY = Math.min(this.mapHeight, Math.ceil((state.viewportHeight - state.panY) / state.zoom));
+    
+    ctx.strokeStyle = 'rgba(100, 100, 100, 0.3)';
+    ctx.lineWidth = 1 / state.zoom;
+    
+    ctx.beginPath();
+    
+    // Vertical lines
+    for (let x = startX; x <= endX; x++) {
+      ctx.moveTo(x, startY);
+      ctx.lineTo(x, endY);
+    }
+    
+    // Horizontal lines
+    for (let y = startY; y <= endY; y++) {
+      ctx.moveTo(startX, y);
+      ctx.lineTo(endX, y);
+    }
+    
+    ctx.stroke();
   }
 
   /**
@@ -821,7 +987,6 @@ export class WebGLRenderer {
   resize(width: number, height: number): void {
     this.canvas.width = width;
     this.canvas.height = height;
-    this.gl.viewport(0, 0, width, height);
   }
 
   /**
@@ -832,25 +997,34 @@ export class WebGLRenderer {
   }
 
   /**
-   * Cleanup WebGL resources
+   * Get renderer type
+   */
+  getRendererType(): 'webgl' | 'canvas2d' {
+    return this.useWebGL ? 'webgl' : 'canvas2d';
+  }
+
+  /**
+   * Cleanup resources
    */
   dispose(): void {
-    const { gl } = this;
+    if (this.gl) {
+      const gl = this.gl;
+      
+      if (this.mapTexture) gl.deleteTexture(this.mapTexture);
+      if (this.highlightTexture) gl.deleteTexture(this.highlightTexture);
+      if (this.quadVAO) gl.deleteVertexArray(this.quadVAO);
+      if (this.lineVAO) gl.deleteVertexArray(this.lineVAO);
+      if (this.quadBuffer) gl.deleteBuffer(this.quadBuffer);
+      if (this.texCoordBuffer) gl.deleteBuffer(this.texCoordBuffer);
+      if (this.lineBuffer) gl.deleteBuffer(this.lineBuffer);
+      if (this.mapProgram) gl.deleteProgram(this.mapProgram);
+      if (this.lineProgram) gl.deleteProgram(this.lineProgram);
+    }
     
-    gl.deleteProgram(this.mainProgram);
-    gl.deleteProgram(this.borderProgram);
-    gl.deleteProgram(this.gridProgram);
-    
-    gl.deleteBuffer(this.positionBuffer);
-    gl.deleteBuffer(this.texCoordBuffer);
-    gl.deleteBuffer(this.borderBuffer);
-    gl.deleteBuffer(this.gridBuffer);
-    
-    gl.deleteVertexArray(this.mainVAO);
-    gl.deleteVertexArray(this.borderVAO);
-    gl.deleteVertexArray(this.gridVAO);
-    
-    gl.deleteTexture(this.mapTexture);
-    gl.deleteTexture(this.overlayTexture);
+    this.mapImageData = null;
+    this.highlightImageData = null;
+    this.provincePixelData = null;
+    this.offscreenCanvas = null;
+    this.offscreenCtx = null;
   }
 }


### PR DESCRIPTION
- Completely rewrote WebGLRenderer.ts with proper WebGL2 implementation
- Added Canvas 2D fallback for browsers without WebGL2 support
- Implemented smooth rendering: LINEAR filter at low zoom, NEAREST at high zoom
- Fixed texture coordinate mapping and VAO buffer initialization
- Added highlight texture for province selection/hover
- Added renderer type indicator in UI (WebGL/Canvas)
- Improved debug logging for map loading

Key changes:
- WebGL2: Full shader-based rendering with GPU texture caching
- Canvas 2D: OffscreenCanvas + ImageData for efficient fallback
- Dynamic texture filtering based on zoom level
- Proper resource cleanup in dispose()