### PR TITLE
feat(map-ide): Add i18n, layer colors, localisation support

### DIFF
--- a/map-ide/src/components/WelcomeScreen.tsx
+++ b/map-ide/src/components/WelcomeScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSettingsStore } from '../stores/settingsStore';
 
 interface WelcomeScreenProps {
   onOpenProject: () => void;
@@ -6,30 +7,29 @@ interface WelcomeScreenProps {
 }
 
 const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onOpenProject, onTestMode }) => {
+  const t = useSettingsStore((state) => state.t);
+  
   return (
     <div className="w-full h-full flex items-center justify-center bg-ide-bg">
       <div className="max-w-lg text-center">
         <h1 className="text-4xl font-bold text-ide-text mb-4">
-          HoI4 Map IDE
+          {t.welcomeTitle}
         </h1>
         <p className="text-ide-text-muted mb-8">
-          Hearts of Iron 4 Map Integrated Development Environment
+          {t.welcomeSubtitle}
         </p>
         
         <div className="bg-ide-panel p-8 rounded-lg border border-ide-border">
-          <h2 className="text-xl text-ide-text mb-4">Get Started</h2>
+          <h2 className="text-xl text-ide-text mb-4">{t.getStarted}</h2>
           <p className="text-ide-text-muted mb-6 text-sm">
-            Open a HoI4 mod folder to begin editing. The folder should contain
-            the standard mod structure with <code className="text-ide-accent">map/</code>,{' '}
-            <code className="text-ide-accent">common/</code>, and{' '}
-            <code className="text-ide-accent">history/</code> directories.
+            {t.welcomeDescription}
           </p>
           
           <button
             onClick={onOpenProject}
             className="px-6 py-3 bg-ide-accent text-white rounded hover:bg-ide-accent-hover transition-colors"
           >
-            Open Mod Folder
+            {t.openModFolder}
           </button>
           
           {onTestMode && (
@@ -37,38 +37,38 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ onOpenProject, onTestMode
               onClick={onTestMode}
               className="ml-4 px-6 py-3 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
             >
-              Test Mode (Demo)
+              {t.testMode}
             </button>
           )}
           
           <div className="mt-6 text-xs text-ide-text-muted">
-            <p>Keyboard shortcut: <kbd className="px-2 py-1 bg-ide-bg rounded">Ctrl/Cmd + O</kbd></p>
+            <p>{t.keyboardShortcut}: <kbd className="px-2 py-1 bg-ide-bg rounded">Ctrl/Cmd + O</kbd></p>
           </div>
         </div>
 
         <div className="mt-8 grid grid-cols-2 gap-4 text-left">
           <div className="bg-ide-sidebar p-4 rounded border border-ide-border">
-            <h3 className="text-ide-text font-semibold mb-2">📍 Province Editing</h3>
+            <h3 className="text-ide-text font-semibold mb-2">📍 {t.provinceEditing}</h3>
             <p className="text-ide-text-muted text-xs">
-              Edit provinces.bmp directly with brush, fill, and selection tools
+              {t.provinceEditingDesc}
             </p>
           </div>
           <div className="bg-ide-sidebar p-4 rounded border border-ide-border">
-            <h3 className="text-ide-text font-semibold mb-2">🗺️ State Management</h3>
+            <h3 className="text-ide-text font-semibold mb-2">🗺️ {t.stateManagement}</h3>
             <p className="text-ide-text-muted text-xs">
-              Manage states, assign provinces, and edit properties
+              {t.stateManagementDesc}
             </p>
           </div>
           <div className="bg-ide-sidebar p-4 rounded border border-ide-border">
-            <h3 className="text-ide-text font-semibold mb-2">🌍 Strategic Regions</h3>
+            <h3 className="text-ide-text font-semibold mb-2">🌍 {t.strategicRegions}</h3>
             <p className="text-ide-text-muted text-xs">
-              View and edit strategic regions with weather settings
+              {t.strategicRegionsDesc}
             </p>
           </div>
           <div className="bg-ide-sidebar p-4 rounded border border-ide-border">
-            <h3 className="text-ide-text font-semibold mb-2">🤖 AI Areas</h3>
+            <h3 className="text-ide-text font-semibold mb-2">🤖 {t.aiAreas}</h3>
             <p className="text-ide-text-muted text-xs">
-              Configure AI areas for strategic region grouping
+              {t.aiAreasDesc}
             </p>
           </div>
         </div>

--- a/map-ide/src/components/layout/Header.tsx
+++ b/map-ide/src/components/layout/Header.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useMapStore } from '../../stores/mapStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { getAvailableLanguages, Language } from '../../i18n';
 import ToolBar from './ToolBar';
 
 interface HeaderProps {
@@ -12,6 +14,11 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
   const bmpEditor = useMapStore((state) => state.bmpEditor);
   const undo = useMapStore((state) => state.undo);
   const redo = useMapStore((state) => state.redo);
+  
+  const t = useSettingsStore((state) => state.t);
+  const language = useSettingsStore((state) => state.language);
+  const setLanguage = useSettingsStore((state) => state.setLanguage);
+  const languages = getAvailableLanguages();
 
   const handleSave = async () => {
     if (!bmpEditor || !project) return;
@@ -24,9 +31,9 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
 
     if (result.success) {
       bmpEditor.markSaved();
-      alert('Saved successfully!');
+      alert(t.saved + '!');
     } else {
-      alert(`Failed to save: ${result.error}`);
+      alert(`${t.error}: ${result.error}`);
     }
   };
 
@@ -35,22 +42,35 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
       {/* Menu Bar */}
       <div className="flex items-center h-8 px-2 text-sm border-b border-ide-border">
         <button className="px-3 py-1 hover:bg-ide-panel text-ide-text rounded">
-          File
+          ファイル
         </button>
         <button className="px-3 py-1 hover:bg-ide-panel text-ide-text rounded">
-          Edit
+          編集
         </button>
         <button className="px-3 py-1 hover:bg-ide-panel text-ide-text rounded">
-          View
+          表示
         </button>
         <button className="px-3 py-1 hover:bg-ide-panel text-ide-text rounded">
-          Map
+          マップ
         </button>
         <button className="px-3 py-1 hover:bg-ide-panel text-ide-text rounded">
-          Help
+          ヘルプ
         </button>
         
         <div className="flex-1" />
+        
+        {/* Language Selector */}
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value as Language)}
+          className="bg-ide-panel text-ide-text text-xs px-2 py-1 rounded border border-ide-border mr-4"
+        >
+          {languages.map((lang) => (
+            <option key={lang.code} value={lang.code}>
+              {lang.name}
+            </option>
+          ))}
+        </select>
         
         {project && (
           <span className="text-ide-text-muted text-xs mr-4">
@@ -65,7 +85,7 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
         <button
           onClick={onOpenProject}
           className="p-2 hover:bg-ide-panel text-ide-text rounded"
-          title="Open Folder (Ctrl+O)"
+          title={`${t.openProjectFolder} (Ctrl+O)`}
         >
           📂
         </button>
@@ -74,7 +94,7 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
           className={`p-2 hover:bg-ide-panel rounded ${
             bmpEditor?.isDirty ? 'text-ide-accent' : 'text-ide-text'
           }`}
-          title="Save (Ctrl+S)"
+          title={`${t.save} (Ctrl+S)`}
           disabled={!bmpEditor}
         >
           💾
@@ -86,7 +106,7 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
         <button
           onClick={() => undo()}
           className="p-2 hover:bg-ide-panel text-ide-text rounded disabled:opacity-50"
-          title="Undo (Ctrl+Z)"
+          title={`${t.undo} (Ctrl+Z)`}
           disabled={!bmpEditor?.canUndo()}
         >
           ↩️
@@ -94,7 +114,7 @@ const Header: React.FC<HeaderProps> = ({ onOpenProject }) => {
         <button
           onClick={() => redo()}
           className="p-2 hover:bg-ide-panel text-ide-text rounded disabled:opacity-50"
-          title="Redo (Ctrl+Shift+Z)"
+          title={`${t.redo} (Ctrl+Shift+Z)`}
           disabled={!bmpEditor?.canRedo()}
         >
           ↪️

--- a/map-ide/src/components/layout/Sidebar.tsx
+++ b/map-ide/src/components/layout/Sidebar.tsx
@@ -1,19 +1,42 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useProjectStore } from '../../stores/projectStore';
 import { useMapStore } from '../../stores/mapStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import ColorPalette from '../panels/ColorPalette';
 
-type Tab = 'project' | 'colors' | 'layers';
+type Tab = 'project' | 'colors' | 'layers' | 'selection';
 
 const Sidebar: React.FC = () => {
   const [activeTab, setActiveTab] = useState<Tab>('colors');
+  const t = useSettingsStore((state) => state.t);
   const project = useProjectStore((state) => state.project);
   const provinces = useProjectStore((state) => state.provinces);
   const states = useProjectStore((state) => state.states);
   const strategicRegions = useProjectStore((state) => state.strategicRegions);
   const aiAreas = useProjectStore((state) => state.aiAreas);
+  const getStateName = useProjectStore((state) => state.getStateName);
+  const getStrategicRegionName = useProjectStore((state) => state.getStrategicRegionName);
   
+  const selectedProvinceId = useMapStore((state) => state.selectedProvinceId);
   const layers = useMapStore((state) => state.layers);
+
+  // Get selected province details
+  const selectedProvince = useMemo(() => {
+    if (!selectedProvinceId) return null;
+    return provinces.get(selectedProvinceId);
+  }, [selectedProvinceId, provinces]);
+
+  // Get state for selected province
+  const selectedState = useMemo(() => {
+    if (!selectedProvince?.stateId) return null;
+    return states.get(selectedProvince.stateId);
+  }, [selectedProvince, states]);
+
+  // Get strategic region for selected province
+  const selectedRegion = useMemo(() => {
+    if (!selectedProvince?.strategicRegionId) return null;
+    return strategicRegions.get(selectedProvince.strategicRegionId);
+  }, [selectedProvince, strategicRegions]);
   const toggleLayer = useMapStore((state) => state.toggleLayer);
   const showGrid = useMapStore((state) => state.showGrid);
   const toggleGrid = useMapStore((state) => state.toggleGrid);
@@ -23,36 +46,46 @@ const Sidebar: React.FC = () => {
   return (
     <div className="w-64 bg-ide-sidebar border-r border-ide-border flex flex-col">
       {/* Tabs */}
-      <div className="flex border-b border-ide-border">
+      <div className="flex border-b border-ide-border flex-wrap">
         <button
           onClick={() => setActiveTab('project')}
-          className={`flex-1 px-3 py-2 text-xs ${
+          className={`flex-1 px-2 py-2 text-xs ${
             activeTab === 'project'
               ? 'bg-ide-panel text-ide-text border-b-2 border-ide-accent'
               : 'text-ide-text-muted hover:bg-ide-panel'
           }`}
         >
-          Project
+          📁
         </button>
         <button
           onClick={() => setActiveTab('colors')}
-          className={`flex-1 px-3 py-2 text-xs ${
+          className={`flex-1 px-2 py-2 text-xs ${
             activeTab === 'colors'
               ? 'bg-ide-panel text-ide-text border-b-2 border-ide-accent'
               : 'text-ide-text-muted hover:bg-ide-panel'
           }`}
         >
-          Colors
+          🎨
         </button>
         <button
           onClick={() => setActiveTab('layers')}
-          className={`flex-1 px-3 py-2 text-xs ${
+          className={`flex-1 px-2 py-2 text-xs ${
             activeTab === 'layers'
               ? 'bg-ide-panel text-ide-text border-b-2 border-ide-accent'
               : 'text-ide-text-muted hover:bg-ide-panel'
           }`}
         >
-          Layers
+          📚
+        </button>
+        <button
+          onClick={() => setActiveTab('selection')}
+          className={`flex-1 px-2 py-2 text-xs ${
+            activeTab === 'selection'
+              ? 'bg-ide-panel text-ide-text border-b-2 border-ide-accent'
+              : 'text-ide-text-muted hover:bg-ide-panel'
+          }`}
+        >
+          🔍
         </button>
       </div>
 
@@ -60,31 +93,31 @@ const Sidebar: React.FC = () => {
       <div className="flex-1 overflow-auto">
         {activeTab === 'project' && (
           <div className="p-2">
-            <div className="text-ide-text-muted text-xs mb-2">Project Info</div>
+            <div className="text-ide-text-muted text-xs mb-2">プロジェクト情報</div>
             
             {project && (
               <div className="space-y-2 text-xs">
                 <div className="bg-ide-panel p-2 rounded">
-                  <div className="text-ide-text font-medium">Statistics</div>
+                  <div className="text-ide-text font-medium">統計</div>
                   <div className="mt-1 space-y-1 text-ide-text-muted">
-                    <div>Provinces: {provinces.size}</div>
-                    <div>States: {states.size}</div>
-                    <div>Strategic Regions: {strategicRegions.size}</div>
-                    <div>AI Areas: {aiAreas.length}</div>
+                    <div>{t.provinces}: {provinces.size}</div>
+                    <div>{t.states}: {states.size}</div>
+                    <div>{t.strategicRegions}: {strategicRegions.size}</div>
+                    <div>{t.aiAreas}: {aiAreas.length}</div>
                   </div>
                 </div>
 
                 <div className="bg-ide-panel p-2 rounded">
-                  <div className="text-ide-text font-medium">Province Types</div>
+                  <div className="text-ide-text font-medium">プロヴィンスタイプ</div>
                   <div className="mt-1 space-y-1 text-ide-text-muted">
                     <div>
-                      Land: {Array.from(provinces.values()).filter((p) => p.type === 'land').length}
+                      陸地: {Array.from(provinces.values()).filter((p) => p.type === 'land').length}
                     </div>
                     <div>
-                      Sea: {Array.from(provinces.values()).filter((p) => p.type === 'sea').length}
+                      海: {Array.from(provinces.values()).filter((p) => p.type === 'sea').length}
                     </div>
                     <div>
-                      Lake: {Array.from(provinces.values()).filter((p) => p.type === 'lake').length}
+                      湖: {Array.from(provinces.values()).filter((p) => p.type === 'lake').length}
                     </div>
                   </div>
                 </div>
@@ -97,7 +130,7 @@ const Sidebar: React.FC = () => {
 
         {activeTab === 'layers' && (
           <div className="p-2">
-            <div className="text-ide-text-muted text-xs mb-2">Layer Visibility</div>
+            <div className="text-ide-text-muted text-xs mb-2">レイヤー表示</div>
             
             <div className="space-y-1">
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -107,7 +140,7 @@ const Sidebar: React.FC = () => {
                   onChange={() => toggleLayer('provinces')}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">Provinces</span>
+                <span className="text-ide-text text-xs">{t.provinces}</span>
               </label>
               
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -117,7 +150,7 @@ const Sidebar: React.FC = () => {
                   onChange={() => toggleLayer('states')}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">States</span>
+                <span className="text-ide-text text-xs">{t.states}</span>
               </label>
               
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -127,7 +160,7 @@ const Sidebar: React.FC = () => {
                   onChange={() => toggleLayer('strategicRegions')}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">Strategic Regions</span>
+                <span className="text-ide-text text-xs">{t.strategicRegions}</span>
               </label>
               
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -137,7 +170,7 @@ const Sidebar: React.FC = () => {
                   onChange={() => toggleLayer('aiAreas')}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">AI Areas</span>
+                <span className="text-ide-text text-xs">{t.aiAreas}</span>
               </label>
               
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -147,7 +180,7 @@ const Sidebar: React.FC = () => {
                   onChange={() => toggleLayer('terrain')}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">Terrain</span>
+                <span className="text-ide-text text-xs">{t.terrain}</span>
               </label>
 
               <div className="h-px bg-ide-border my-2" />
@@ -159,7 +192,7 @@ const Sidebar: React.FC = () => {
                   onChange={toggleGrid}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">Pixel Grid</span>
+                <span className="text-ide-text text-xs">{t.showGrid}</span>
               </label>
               
               <label className="flex items-center gap-2 p-2 hover:bg-ide-panel rounded cursor-pointer">
@@ -169,9 +202,91 @@ const Sidebar: React.FC = () => {
                   onChange={toggleBorders}
                   className="accent-ide-accent"
                 />
-                <span className="text-ide-text text-xs">Province Borders</span>
+                <span className="text-ide-text text-xs">{t.showBorders}</span>
               </label>
             </div>
+          </div>
+        )}
+
+        {activeTab === 'selection' && (
+          <div className="p-2">
+            <div className="text-ide-text-muted text-xs mb-2">選択情報</div>
+            
+            {!selectedProvince ? (
+              <div className="text-ide-text-muted text-xs p-2">
+                マップ上でプロヴィンスを選択してください
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {/* Province Info */}
+                <div className="bg-ide-panel p-2 rounded">
+                  <div className="text-ide-text font-medium text-sm flex items-center gap-1">
+                    🟡 {t.provinces}
+                  </div>
+                  <div className="mt-1 space-y-1 text-ide-text-muted text-xs">
+                    <div><span className="text-ide-text">ID:</span> {selectedProvince.id}</div>
+                    <div>
+                      <span className="text-ide-text">色:</span>{' '}
+                      <span 
+                        className="inline-block w-3 h-3 rounded"
+                        style={{ 
+                          backgroundColor: `rgb(${selectedProvince.color.r},${selectedProvince.color.g},${selectedProvince.color.b})`,
+                          verticalAlign: 'middle'
+                        }}
+                      />
+                      {' '}({selectedProvince.color.r}, {selectedProvince.color.g}, {selectedProvince.color.b})
+                    </div>
+                    <div><span className="text-ide-text">タイプ:</span> {selectedProvince.type}</div>
+                    <div><span className="text-ide-text">地形:</span> {selectedProvince.terrain}</div>
+                    {selectedProvince.coastal && (
+                      <div className="text-blue-400">🌊 沿岸プロヴィンス</div>
+                    )}
+                  </div>
+                </div>
+
+                {/* State Info */}
+                {selectedState && (
+                  <div className="bg-ide-panel p-2 rounded">
+                    <div className="text-ide-text font-medium text-sm flex items-center gap-1">
+                      🟠 {t.states}
+                    </div>
+                    <div className="mt-1 space-y-1 text-ide-text-muted text-xs">
+                      <div><span className="text-ide-text">ID:</span> {selectedState.id}</div>
+                      <div>
+                        <span className="text-ide-text">名前:</span>{' '}
+                        <span className="text-yellow-300">{getStateName(selectedState.id)}</span>
+                      </div>
+                      <div><span className="text-ide-text">カテゴリ:</span> {selectedState.stateCategory}</div>
+                      <div><span className="text-ide-text">人口:</span> {selectedState.manpower?.toLocaleString() || 0}</div>
+                      <div><span className="text-ide-text">プロヴィンス数:</span> {selectedState.provinces.length}</div>
+                      {selectedState.owner && (
+                        <div><span className="text-ide-text">所有者:</span> {selectedState.owner}</div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* Strategic Region Info */}
+                {selectedRegion && (
+                  <div className="bg-ide-panel p-2 rounded">
+                    <div className="text-ide-text font-medium text-sm flex items-center gap-1">
+                      🔵 {t.strategicRegions}
+                    </div>
+                    <div className="mt-1 space-y-1 text-ide-text-muted text-xs">
+                      <div><span className="text-ide-text">ID:</span> {selectedRegion.id}</div>
+                      <div>
+                        <span className="text-ide-text">名前:</span>{' '}
+                        <span className="text-cyan-300">{getStrategicRegionName(selectedRegion.id)}</span>
+                      </div>
+                      <div><span className="text-ide-text">プロヴィンス数:</span> {selectedRegion.provinces.length}</div>
+                      {selectedRegion.weather && selectedRegion.weather.length > 0 && (
+                        <div><span className="text-ide-text">天候期間数:</span> {selectedRegion.weather.length}</div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/map-ide/src/components/layout/ToolBar.tsx
+++ b/map-ide/src/components/layout/ToolBar.tsx
@@ -1,19 +1,10 @@
 import React from 'react';
 import { useMapStore } from '../../stores/mapStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import { ToolType } from '../../types';
 
-const tools: { type: ToolType; icon: string; label: string; shortcut: string }[] = [
-  { type: 'select', icon: '👆', label: 'Select', shortcut: 'V' },
-  { type: 'brush', icon: '🖌️', label: 'Brush', shortcut: 'B' },
-  { type: 'fill', icon: '🪣', label: 'Fill', shortcut: 'G' },
-  { type: 'pencil', icon: '✏️', label: 'Pencil', shortcut: 'P' },
-  { type: 'eyedropper', icon: '🔍', label: 'Eyedropper', shortcut: 'I' },
-  { type: 'eraser', icon: '🧹', label: 'Eraser', shortcut: 'E' },
-  { type: 'line', icon: '📐', label: 'Line', shortcut: 'L' },
-  { type: 'rectangle', icon: '🔲', label: 'Rectangle', shortcut: 'R' },
-];
-
 const ToolBar: React.FC = () => {
+  const t = useSettingsStore((state) => state.t);
   const activeTool = useMapStore((state) => state.activeTool);
   const setActiveTool = useMapStore((state) => state.setActiveTool);
   const brushSize = useMapStore((state) => state.brushSize);
@@ -25,6 +16,17 @@ const ToolBar: React.FC = () => {
   const zoomOut = useMapStore((state) => state.zoomOut);
   const fitToView = useMapStore((state) => state.fitToView);
   const zoom = useMapStore((state) => state.zoom);
+
+  const tools: { type: ToolType; icon: string; label: string; shortcut: string }[] = [
+    { type: 'select', icon: '👆', label: t.select, shortcut: 'V' },
+    { type: 'brush', icon: '🖌️', label: t.brush, shortcut: 'B' },
+    { type: 'fill', icon: '🪣', label: t.fill, shortcut: 'G' },
+    { type: 'pencil', icon: '✏️', label: t.pencil, shortcut: 'P' },
+    { type: 'eyedropper', icon: '🔍', label: t.eyedropper, shortcut: 'I' },
+    { type: 'eraser', icon: '🧹', label: t.eraser, shortcut: 'E' },
+    { type: 'line', icon: '📐', label: t.line, shortcut: 'L' },
+    { type: 'rectangle', icon: '🔲', label: t.rectangle, shortcut: 'R' },
+  ];
 
   return (
     <div className="flex items-center gap-1">
@@ -50,7 +52,7 @@ const ToolBar: React.FC = () => {
       {(activeTool === 'brush' || activeTool === 'eraser') && (
         <>
           <div className="flex items-center gap-2 mx-2">
-            <span className="text-ide-text-muted text-xs">Size:</span>
+            <span className="text-ide-text-muted text-xs">{t.brushSize}:</span>
             <input
               type="range"
               min="1"
@@ -70,6 +72,7 @@ const ToolBar: React.FC = () => {
                   ? 'bg-ide-accent text-white'
                   : 'bg-ide-panel text-ide-text'
               }`}
+              title={t.circle}
             >
               ●
             </button>
@@ -80,6 +83,7 @@ const ToolBar: React.FC = () => {
                   ? 'bg-ide-accent text-white'
                   : 'bg-ide-panel text-ide-text'
               }`}
+              title={t.square}
             >
               ■
             </button>
@@ -92,7 +96,7 @@ const ToolBar: React.FC = () => {
       {/* Selected Color */}
       {selectedColor && (
         <div className="flex items-center gap-2 mx-2">
-          <span className="text-ide-text-muted text-xs">Color:</span>
+          <span className="text-ide-text-muted text-xs">{t.selectedColor}:</span>
           <div
             className="w-6 h-6 border border-ide-border rounded"
             style={{
@@ -110,7 +114,7 @@ const ToolBar: React.FC = () => {
         <button
           onClick={zoomOut}
           className="p-1 hover:bg-ide-panel text-ide-text rounded"
-          title="Zoom Out (-)"
+          title="ズームアウト (-)"
         >
           ➖
         </button>
@@ -120,14 +124,14 @@ const ToolBar: React.FC = () => {
         <button
           onClick={zoomIn}
           className="p-1 hover:bg-ide-panel text-ide-text rounded"
-          title="Zoom In (+)"
+          title="ズームイン (+)"
         >
           ➕
         </button>
         <button
           onClick={fitToView}
           className="p-1 hover:bg-ide-panel text-ide-text rounded ml-1"
-          title="Fit to View"
+          title="全体表示"
         >
           🔳
         </button>

--- a/map-ide/src/components/map/WebGLMapCanvas.tsx
+++ b/map-ide/src/components/map/WebGLMapCanvas.tsx
@@ -6,8 +6,19 @@
 import React, { useRef, useEffect, useCallback, useState, useMemo } from 'react';
 import { useMapStore } from '../../stores/mapStore';
 import { useProjectStore } from '../../stores/projectStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import { WebGLRenderer, RenderState } from '../../core/WebGLRenderer';
 import { rgbToKey } from '../../utils/colorUtils';
+import {
+  buildStateAdjacency,
+  buildStrategicRegionAdjacency,
+  buildAIAreaAdjacency,
+  generateStateColors,
+  generateStrategicRegionColors,
+  generateAIAreaColors,
+  createLayerOverlay,
+} from '../../utils/layerColors';
+import { RGB } from '../../types';
 
 interface MouseState {
   isDragging: boolean;
@@ -32,6 +43,15 @@ const WebGLMapCanvas: React.FC = () => {
   const [rendererType, setRendererType] = useState<'webgl' | 'canvas2d' | 'none'>('none');
   const [rendererReady, setRendererReady] = useState(false);
   const [debugInfo, setDebugInfo] = useState<string>('');
+  
+  // Layer color caches
+  const [stateColors, setStateColors] = useState<Map<number, RGB>>(new Map());
+  const [regionColors, setRegionColors] = useState<Map<number, RGB>>(new Map());
+  const [aiAreaColors, setAIAreaColors] = useState<Map<string, RGB>>(new Map());
+  const [layerOverlay, setLayerOverlay] = useState<Uint8Array | null>(null);
+  
+  // i18n
+  const t = useSettingsStore((state) => state.t);
 
   // Map store state
   const bmpEditor = useMapStore((state) => state.bmpEditor);
@@ -146,26 +166,127 @@ const WebGLMapCanvas: React.FC = () => {
     renderer.updateMapTexture(bmpEditor.pixels);
   }, [bmpEditor?.pixels]);
 
-  // Generate borders when data changes
+  // Generate borders and layer colors when data changes
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer || !bmpEditor || provinces.size === 0) return;
 
-    // Generate state borders
+    console.log('[WebGLMapCanvas] Generating borders and colors...');
+
+    // Build adjacency graphs and generate colors
     if (states.size > 0) {
+      // Generate state borders
       renderer.generateStateBorders(states, provinces, provinceByColor);
-    }
+      
+      // Build state adjacency and colors
+      const stateAdj = buildStateAdjacency(
+        states, provinces, bmpEditor.pixels, bmpEditor.width, bmpEditor.height, provinceByColor
+      );
+      const colors = generateStateColors(states, stateAdj);
+      setStateColors(colors);
+      console.log('[WebGLMapCanvas] Generated colors for', colors.size, 'states');
+      
+      // Build strategic region adjacency based on state adjacency
+      if (strategicRegions.size > 0) {
+        renderer.generateStrategicRegionBorders(strategicRegions, provinces, provinceByColor);
+        
+        const regionAdj = buildStrategicRegionAdjacency(strategicRegions, states, stateAdj);
+        const rColors = generateStrategicRegionColors(strategicRegions, regionAdj);
+        setRegionColors(rColors);
+        console.log('[WebGLMapCanvas] Generated colors for', rColors.size, 'strategic regions');
+        
+        // Build AI area adjacency based on region adjacency
+        if (aiAreas.length > 0) {
+          renderer.generateAIAreaBorders(aiAreas, strategicRegions, provinces, provinceByColor);
+          
+          const aiAdj = buildAIAreaAdjacency(aiAreas, regionAdj);
+          const aColors = generateAIAreaColors(aiAreas, aiAdj);
+          setAIAreaColors(aColors);
+          console.log('[WebGLMapCanvas] Generated colors for', aColors.size, 'AI areas');
+        }
+      }
+    } else {
+      // Generate strategic region borders even without states
+      if (strategicRegions.size > 0) {
+        renderer.generateStrategicRegionBorders(strategicRegions, provinces, provinceByColor);
+      }
 
-    // Generate strategic region borders
-    if (strategicRegions.size > 0) {
-      renderer.generateStrategicRegionBorders(strategicRegions, provinces, provinceByColor);
-    }
-
-    // Generate AI area borders
-    if (aiAreas.length > 0) {
-      renderer.generateAIAreaBorders(aiAreas, strategicRegions, provinces, provinceByColor);
+      // Generate AI area borders
+      if (aiAreas.length > 0) {
+        renderer.generateAIAreaBorders(aiAreas, strategicRegions, provinces, provinceByColor);
+      }
     }
   }, [bmpEditor, provinces, provinceByColor, states, strategicRegions, aiAreas]);
+
+  // Generate layer overlay when active layer or colors change
+  useEffect(() => {
+    if (!bmpEditor || provinces.size === 0) {
+      setLayerOverlay(null);
+      return;
+    }
+
+    let overlay: Uint8Array | null = null;
+    let provinceToEntity: Map<number, number | string> | null = null;
+    let entityColors: Map<number | string, RGB> | null = null;
+
+    if (activeLayer === 'states' && stateColors.size > 0) {
+      // Map provinces to states
+      provinceToEntity = new Map();
+      for (const [stateId, state] of states) {
+        for (const provId of state.provinces) {
+          provinceToEntity.set(provId, stateId);
+        }
+      }
+      entityColors = stateColors as Map<number | string, RGB>;
+    } else if (activeLayer === 'strategicRegions' && regionColors.size > 0) {
+      // Map provinces to regions
+      provinceToEntity = new Map();
+      for (const [regionId, region] of strategicRegions) {
+        for (const provId of region.provinces) {
+          provinceToEntity.set(provId, regionId);
+        }
+      }
+      entityColors = regionColors as Map<number | string, RGB>;
+    } else if (activeLayer === 'aiAreas' && aiAreaColors.size > 0) {
+      // Map provinces to AI areas via regions
+      provinceToEntity = new Map();
+      for (const area of aiAreas) {
+        if (area.strategicRegions) {
+          for (const regionId of area.strategicRegions) {
+            const region = strategicRegions.get(regionId);
+            if (region) {
+              for (const provId of region.provinces) {
+                provinceToEntity.set(provId, area.name);
+              }
+            }
+          }
+        }
+      }
+      entityColors = aiAreaColors as Map<number | string, RGB>;
+    }
+
+    if (provinceToEntity && entityColors && provinceToEntity.size > 0 && entityColors.size > 0) {
+      overlay = createLayerOverlay(
+        bmpEditor.width,
+        bmpEditor.height,
+        bmpEditor.pixels,
+        provinceByColor,
+        provinceToEntity,
+        entityColors,
+        0.6 // opacity
+      );
+      console.log('[WebGLMapCanvas] Created layer overlay for', activeLayer);
+    }
+
+    setLayerOverlay(overlay);
+
+    // Upload to renderer
+    const renderer = rendererRef.current;
+    if (renderer) {
+      renderer.uploadLayerOverlay(overlay);
+    }
+  }, [activeLayer, bmpEditor, provinces, provinceByColor, states, strategicRegions, aiAreas,
+      stateColors, regionColors, aiAreaColors]);
 
   // Update highlight overlay
   useEffect(() => {
@@ -208,7 +329,8 @@ const WebGLMapCanvas: React.FC = () => {
           selectedProvinceId,
           hoveredProvinceId,
           activeLayer,
-          layerOpacity: 0.7,
+          layerOpacity: 0.6,
+          layerOverlay,
         };
         renderer.render(renderState);
       }
@@ -218,7 +340,7 @@ const WebGLMapCanvas: React.FC = () => {
     animationFrameRef.current = requestAnimationFrame(render);
     return () => cancelAnimationFrame(animationFrameRef.current);
   }, [zoom, panX, panY, viewportWidth, viewportHeight, showGrid, showBorders, 
-      selectedProvinceId, hoveredProvinceId, activeLayer]);
+      selectedProvinceId, hoveredProvinceId, activeLayer, layerOverlay]);
 
   // Convert screen coordinates to image coordinates
   const screenToImage = useCallback(
@@ -462,9 +584,9 @@ const WebGLMapCanvas: React.FC = () => {
         <div className="absolute inset-0 flex items-center justify-center bg-ide-bg text-ide-text-muted">
           <div className="text-center">
             <div className="text-6xl mb-4">🗺️</div>
-            <div className="text-xl font-medium">Loading map...</div>
+            <div className="text-xl font-medium">{t.loadingMap}</div>
             <div className="text-sm mt-2 text-ide-text-muted">
-              Open a project folder to start editing
+              {t.welcomeDescription}
             </div>
           </div>
         </div>
@@ -472,12 +594,12 @@ const WebGLMapCanvas: React.FC = () => {
       
       {/* Layer indicator */}
       <div className="absolute top-4 right-4 bg-ide-sidebar px-3 py-2 rounded-lg shadow-lg border border-ide-border">
-        <div className="text-xs text-ide-text-muted mb-1">Active Layer</div>
+        <div className="text-xs text-ide-text-muted mb-1">{t.activeLayer}</div>
         <div className="text-sm font-medium text-ide-text">
-          {activeLayer === 'provinces' && '🟡 Provinces'}
-          {activeLayer === 'states' && '🟠 States'}
-          {activeLayer === 'strategicRegions' && '🔵 Strategic Regions'}
-          {activeLayer === 'aiAreas' && '🟣 AI Areas'}
+          {activeLayer === 'provinces' && `🟡 ${t.provinces}`}
+          {activeLayer === 'states' && `🟠 ${t.states}`}
+          {activeLayer === 'strategicRegions' && `🔵 ${t.strategicRegions}`}
+          {activeLayer === 'aiAreas' && `🟣 ${t.aiAreas}`}
         </div>
       </div>
       
@@ -487,14 +609,14 @@ const WebGLMapCanvas: React.FC = () => {
           {(zoom * 100).toFixed(0)}%
         </div>
         <div className="text-xs text-ide-text-muted mt-1">
-          {rendererType === 'webgl' ? '🎮 WebGL' : rendererType === 'canvas2d' ? '🖌️ Canvas' : '⏳'}
+          {rendererType === 'webgl' ? `🎮 ${t.webgl}` : rendererType === 'canvas2d' ? `🖌️ ${t.canvas}` : '⏳'}
         </div>
       </div>
       
       {/* Coordinate indicator */}
       {hoveredProvinceId && (
         <div className="absolute bottom-4 left-4 bg-ide-sidebar px-3 py-2 rounded-lg shadow-lg border border-ide-border">
-          <div className="text-xs text-ide-text-muted">Province ID</div>
+          <div className="text-xs text-ide-text-muted">{t.provinceId}</div>
           <div className="text-sm font-mono text-ide-text">{hoveredProvinceId}</div>
         </div>
       )}

--- a/map-ide/src/core/WebGLRenderer.ts
+++ b/map-ide/src/core/WebGLRenderer.ts
@@ -23,6 +23,7 @@ export interface RenderState {
   hoveredProvinceId: number | null;
   activeLayer: 'provinces' | 'states' | 'strategicRegions' | 'aiAreas';
   layerOpacity: number;
+  layerOverlay?: Uint8Array | null; // RGBA overlay for layer coloring
 }
 
 // Vertex shader for WebGL rendering
@@ -59,8 +60,10 @@ in vec2 v_texCoord;
 
 uniform sampler2D u_mapTexture;
 uniform sampler2D u_highlightTexture;
+uniform sampler2D u_layerTexture;
 uniform float u_zoom;
 uniform bool u_useSmoothing;
+uniform bool u_useLayerOverlay;
 
 out vec4 outColor;
 
@@ -74,6 +77,14 @@ void main() {
   } else {
     // Use nearest neighbor for pixel-perfect at high zoom
     mapColor = texture(u_mapTexture, v_texCoord);
+  }
+  
+  // Get layer overlay (state/region colors)
+  if (u_useLayerOverlay) {
+    vec4 layerColor = texture(u_layerTexture, v_texCoord);
+    if (layerColor.a > 0.0) {
+      mapColor = mix(mapColor, layerColor, layerColor.a);
+    }
   }
   
   // Get highlight overlay
@@ -134,6 +145,7 @@ export class WebGLRenderer {
   private lineProgram: WebGLProgram | null = null;
   private mapTexture: WebGLTexture | null = null;
   private highlightTexture: WebGLTexture | null = null;
+  private layerTexture: WebGLTexture | null = null;
   private quadVAO: WebGLVertexArrayObject | null = null;
   private quadBuffer: WebGLBuffer | null = null;
   private texCoordBuffer: WebGLBuffer | null = null;
@@ -215,6 +227,7 @@ export class WebGLRenderer {
     // Create textures
     this.mapTexture = this.createTexture();
     this.highlightTexture = this.createTexture();
+    this.layerTexture = this.createTexture();
     
     // Enable blending
     gl.enable(gl.BLEND);
@@ -418,6 +431,19 @@ export class WebGLRenderer {
       this.uploadMapTextureWebGL(pixels, this.mapWidth, this.mapHeight);
     } else {
       this.createMapImageData(pixels, this.mapWidth, this.mapHeight);
+    }
+  }
+
+  /**
+   * Upload layer overlay data (RGBA)
+   */
+  uploadLayerOverlay(overlayData: Uint8Array | null): void {
+    if (!this.mapWidth || !this.mapHeight) return;
+    
+    if (this.useWebGL && this.gl && this.layerTexture && overlayData) {
+      const gl = this.gl;
+      gl.bindTexture(gl.TEXTURE_2D, this.layerTexture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, this.mapWidth, this.mapHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, overlayData);
     }
   }
 
@@ -736,12 +762,18 @@ export class WebGLRenderer {
     const smoothLoc = gl.getUniformLocation(this.mapProgram, 'u_useSmoothing');
     const mapTexLoc = gl.getUniformLocation(this.mapProgram, 'u_mapTexture');
     const highlightTexLoc = gl.getUniformLocation(this.mapProgram, 'u_highlightTexture');
+    const layerTexLoc = gl.getUniformLocation(this.mapProgram, 'u_layerTexture');
+    const useLayerOverlayLoc = gl.getUniformLocation(this.mapProgram, 'u_useLayerOverlay');
     
     gl.uniform2f(resLoc, state.viewportWidth, state.viewportHeight);
     gl.uniform2f(transLoc, state.panX, state.panY);
     gl.uniform1f(scaleLoc, state.zoom);
     gl.uniform1f(zoomLoc, state.zoom);
     gl.uniform1i(smoothLoc, state.zoom < 4 ? 1 : 0);
+    
+    // Set layer overlay state
+    const hasLayerOverlay = state.layerOverlay && state.layerOverlay.length > 0;
+    gl.uniform1i(useLayerOverlayLoc, hasLayerOverlay ? 1 : 0);
     
     // Bind textures
     gl.activeTexture(gl.TEXTURE0);
@@ -751,6 +783,10 @@ export class WebGLRenderer {
     gl.activeTexture(gl.TEXTURE1);
     gl.bindTexture(gl.TEXTURE_2D, this.highlightTexture);
     gl.uniform1i(highlightTexLoc, 1);
+    
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, this.layerTexture);
+    gl.uniform1i(layerTexLoc, 2);
     
     // Update texture filtering based on zoom
     gl.bindTexture(gl.TEXTURE_2D, this.mapTexture);

--- a/map-ide/src/i18n/index.ts
+++ b/map-ide/src/i18n/index.ts
@@ -1,0 +1,355 @@
+/**
+ * Internationalization (i18n) system for HoI4 Map IDE
+ * Supports Japanese and English
+ */
+
+export type Language = 'ja' | 'en';
+
+export interface I18nStrings {
+  // App
+  appTitle: string;
+  loadingProject: string;
+  loadingMap: string;
+  openProjectFolder: string;
+  
+  // Welcome Screen
+  welcomeTitle: string;
+  welcomeSubtitle: string;
+  getStarted: string;
+  welcomeDescription: string;
+  openModFolder: string;
+  testMode: string;
+  keyboardShortcut: string;
+  
+  // Features
+  provinceEditing: string;
+  provinceEditingDesc: string;
+  stateManagement: string;
+  stateManagementDesc: string;
+  strategicRegions: string;
+  strategicRegionsDesc: string;
+  aiAreas: string;
+  aiAreasDesc: string;
+  
+  // Tools
+  tools: string;
+  select: string;
+  brush: string;
+  pencil: string;
+  eraser: string;
+  fill: string;
+  eyedropper: string;
+  line: string;
+  rectangle: string;
+  
+  // Layers
+  layers: string;
+  provinces: string;
+  states: string;
+  terrain: string;
+  showGrid: string;
+  showBorders: string;
+  activeLayer: string;
+  
+  // Panels
+  properties: string;
+  search: string;
+  validation: string;
+  colors: string;
+  
+  // Properties Panel
+  noSelection: string;
+  provinceId: string;
+  provinceColor: string;
+  provinceType: string;
+  coastal: string;
+  terrain_field: string;
+  continent: string;
+  belongsToState: string;
+  stateId: string;
+  stateName: string;
+  stateProvinces: string;
+  manpower: string;
+  owner: string;
+  regionId: string;
+  regionName: string;
+  regionProvinces: string;
+  weather: string;
+  navalTerrain: string;
+  
+  // Search
+  searchPlaceholder: string;
+  searchResults: string;
+  noResults: string;
+  
+  // Validation
+  validationTitle: string;
+  noIssues: string;
+  errors: string;
+  warnings: string;
+  
+  // Actions
+  save: string;
+  saving: string;
+  saved: string;
+  unsaved: string;
+  error: string;
+  undo: string;
+  redo: string;
+  autoSave: string;
+  
+  // Settings
+  settings: string;
+  language: string;
+  
+  // Status
+  zoomLevel: string;
+  renderer: string;
+  webgl: string;
+  canvas: string;
+  
+  // Brush settings
+  brushSize: string;
+  brushShape: string;
+  circle: string;
+  square: string;
+  selectedColor: string;
+  noColorSelected: string;
+}
+
+const ja: I18nStrings = {
+  // App
+  appTitle: 'HoI4 Map IDE',
+  loadingProject: 'プロジェクトを読み込み中...',
+  loadingMap: 'マップを読み込み中...',
+  openProjectFolder: 'プロジェクトフォルダを開く',
+  
+  // Welcome Screen
+  welcomeTitle: 'HoI4 Map IDE',
+  welcomeSubtitle: 'Hearts of Iron 4 マップ統合開発環境',
+  getStarted: 'はじめに',
+  welcomeDescription: 'HoI4のmodフォルダを開いて編集を開始します。フォルダには map/、common/、history/ ディレクトリが含まれている必要があります。',
+  openModFolder: 'Modフォルダを開く',
+  testMode: 'テストモード（デモ）',
+  keyboardShortcut: 'キーボードショートカット',
+  
+  // Features
+  provinceEditing: 'プロヴィンス編集',
+  provinceEditingDesc: 'ブラシ、塗りつぶし、選択ツールでprovinces.bmpを直接編集',
+  stateManagement: 'ステート管理',
+  stateManagementDesc: 'ステートの管理、プロヴィンスの割り当て、プロパティの編集',
+  strategicRegions: '戦略地域',
+  strategicRegionsDesc: '天候設定付きの戦略地域の表示・編集',
+  aiAreas: 'AIエリア',
+  aiAreasDesc: '戦略地域グループ化のためのAIエリア設定',
+  
+  // Tools
+  tools: 'ツール',
+  select: '選択',
+  brush: 'ブラシ',
+  pencil: 'ペンシル',
+  eraser: '消しゴム',
+  fill: '塗りつぶし',
+  eyedropper: 'スポイト',
+  line: '直線',
+  rectangle: '矩形',
+  
+  // Layers
+  layers: 'レイヤー',
+  provinces: 'プロヴィンス',
+  states: 'ステート',
+  terrain: '地形',
+  showGrid: 'グリッドを表示',
+  showBorders: '境界を表示',
+  activeLayer: 'アクティブレイヤー',
+  
+  // Panels
+  properties: 'プロパティ',
+  search: '検索',
+  validation: '検証',
+  colors: '色',
+  
+  // Properties Panel
+  noSelection: '選択なし',
+  provinceId: 'プロヴィンスID',
+  provinceColor: '色',
+  provinceType: 'タイプ',
+  coastal: '沿岸',
+  terrain_field: '地形',
+  continent: '大陸',
+  belongsToState: '所属ステート',
+  stateId: 'ステートID',
+  stateName: 'ステート名',
+  stateProvinces: 'プロヴィンス数',
+  manpower: '人的資源',
+  owner: '所有国',
+  regionId: '地域ID',
+  regionName: '地域名',
+  regionProvinces: 'プロヴィンス数',
+  weather: '天候',
+  navalTerrain: '海上地形',
+  
+  // Search
+  searchPlaceholder: 'ID、名前、色で検索...',
+  searchResults: '検索結果',
+  noResults: '結果なし',
+  
+  // Validation
+  validationTitle: '検証',
+  noIssues: '問題なし',
+  errors: 'エラー',
+  warnings: '警告',
+  
+  // Actions
+  save: '保存',
+  saving: '保存中...',
+  saved: '保存済み',
+  unsaved: '未保存',
+  error: 'エラー',
+  undo: '元に戻す',
+  redo: 'やり直し',
+  autoSave: '自動保存',
+  
+  // Settings
+  settings: '設定',
+  language: '言語',
+  
+  // Status
+  zoomLevel: 'ズーム',
+  renderer: 'レンダラー',
+  webgl: 'WebGL',
+  canvas: 'Canvas',
+  
+  // Brush settings
+  brushSize: 'ブラシサイズ',
+  brushShape: 'ブラシ形状',
+  circle: '円形',
+  square: '四角形',
+  selectedColor: '選択中の色',
+  noColorSelected: '色が選択されていません',
+};
+
+const en: I18nStrings = {
+  // App
+  appTitle: 'HoI4 Map IDE',
+  loadingProject: 'Loading project...',
+  loadingMap: 'Loading map...',
+  openProjectFolder: 'Open Project Folder',
+  
+  // Welcome Screen
+  welcomeTitle: 'HoI4 Map IDE',
+  welcomeSubtitle: 'Hearts of Iron 4 Map Integrated Development Environment',
+  getStarted: 'Get Started',
+  welcomeDescription: 'Open a HoI4 mod folder to begin editing. The folder should contain map/, common/, and history/ directories.',
+  openModFolder: 'Open Mod Folder',
+  testMode: 'Test Mode (Demo)',
+  keyboardShortcut: 'Keyboard shortcut',
+  
+  // Features
+  provinceEditing: 'Province Editing',
+  provinceEditingDesc: 'Edit provinces.bmp directly with brush, fill, and selection tools',
+  stateManagement: 'State Management',
+  stateManagementDesc: 'Manage states, assign provinces, and edit properties',
+  strategicRegions: 'Strategic Regions',
+  strategicRegionsDesc: 'View and edit strategic regions with weather settings',
+  aiAreas: 'AI Areas',
+  aiAreasDesc: 'Configure AI areas for strategic region grouping',
+  
+  // Tools
+  tools: 'Tools',
+  select: 'Select',
+  brush: 'Brush',
+  pencil: 'Pencil',
+  eraser: 'Eraser',
+  fill: 'Fill',
+  eyedropper: 'Eyedropper',
+  line: 'Line',
+  rectangle: 'Rectangle',
+  
+  // Layers
+  layers: 'Layers',
+  provinces: 'Provinces',
+  states: 'States',
+  terrain: 'Terrain',
+  showGrid: 'Show Grid',
+  showBorders: 'Show Borders',
+  activeLayer: 'Active Layer',
+  
+  // Panels
+  properties: 'Properties',
+  search: 'Search',
+  validation: 'Validation',
+  colors: 'Colors',
+  
+  // Properties Panel
+  noSelection: 'No Selection',
+  provinceId: 'Province ID',
+  provinceColor: 'Color',
+  provinceType: 'Type',
+  coastal: 'Coastal',
+  terrain_field: 'Terrain',
+  continent: 'Continent',
+  belongsToState: 'Belongs to State',
+  stateId: 'State ID',
+  stateName: 'State Name',
+  stateProvinces: 'Provinces',
+  manpower: 'Manpower',
+  owner: 'Owner',
+  regionId: 'Region ID',
+  regionName: 'Region Name',
+  regionProvinces: 'Provinces',
+  weather: 'Weather',
+  navalTerrain: 'Naval Terrain',
+  
+  // Search
+  searchPlaceholder: 'Search by ID, name, or color...',
+  searchResults: 'Search Results',
+  noResults: 'No results',
+  
+  // Validation
+  validationTitle: 'Validation',
+  noIssues: 'No issues',
+  errors: 'Errors',
+  warnings: 'Warnings',
+  
+  // Actions
+  save: 'Save',
+  saving: 'Saving...',
+  saved: 'Saved',
+  unsaved: 'Unsaved',
+  error: 'Error',
+  undo: 'Undo',
+  redo: 'Redo',
+  autoSave: 'Auto-save',
+  
+  // Settings
+  settings: 'Settings',
+  language: 'Language',
+  
+  // Status
+  zoomLevel: 'Zoom',
+  renderer: 'Renderer',
+  webgl: 'WebGL',
+  canvas: 'Canvas',
+  
+  // Brush settings
+  brushSize: 'Brush Size',
+  brushShape: 'Brush Shape',
+  circle: 'Circle',
+  square: 'Square',
+  selectedColor: 'Selected Color',
+  noColorSelected: 'No color selected',
+};
+
+const translations: Record<Language, I18nStrings> = { ja, en };
+
+export function getTranslations(lang: Language): I18nStrings {
+  return translations[lang];
+}
+
+export function getAvailableLanguages(): { code: Language; name: string }[] {
+  return [
+    { code: 'ja', name: '日本語' },
+    { code: 'en', name: 'English' },
+  ];
+}

--- a/map-ide/src/parsers/localisationParser.ts
+++ b/map-ide/src/parsers/localisationParser.ts
@@ -1,0 +1,163 @@
+/**
+ * HoI4 Localisation Parser
+ * Parses .yml localisation files and extracts key-value pairs
+ * Handles STATE_X, STRATEGICREGION_X format
+ */
+
+export interface LocalisationData {
+  states: Map<number, string>;       // STATE_X -> name
+  strategicRegions: Map<number, string>; // STRATEGICREGION_X -> name
+  countries: Map<string, string>;    // TAG -> name
+  other: Map<string, string>;        // other keys
+}
+
+/**
+ * Parse a single localisation file content
+ */
+export function parseLocalisationFile(content: string): Map<string, string> {
+  const result = new Map<string, string>();
+  const lines = content.split('\n');
+  
+  // Skip BOM and first line (l_japanese: or l_english:)
+  let startIndex = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('l_') && line.endsWith(':')) {
+      startIndex = i + 1;
+      break;
+    }
+  }
+  
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i];
+    
+    // Skip empty lines and comments
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    
+    // Parse key:version "value" or key: "value"
+    // Examples:
+    // STATE_183: "南キプロス"
+    // STRATEGICREGION_1:0 "イングランド南部"
+    const match = line.match(/^\s*([A-Za-z0-9_]+):(?:\d+)?\s*"(.*)"\s*$/);
+    if (match) {
+      const [, key, value] = match;
+      result.set(key, value);
+    }
+  }
+  
+  return result;
+}
+
+/**
+ * Extract state names from parsed localisation data
+ */
+export function extractStateNames(data: Map<string, string>): Map<number, string> {
+  const states = new Map<number, string>();
+  
+  for (const [key, value] of data) {
+    const match = key.match(/^STATE_(\d+)$/);
+    if (match) {
+      const stateId = parseInt(match[1], 10);
+      states.set(stateId, value);
+    }
+  }
+  
+  return states;
+}
+
+/**
+ * Extract strategic region names from parsed localisation data
+ */
+export function extractStrategicRegionNames(data: Map<string, string>): Map<number, string> {
+  const regions = new Map<number, string>();
+  
+  for (const [key, value] of data) {
+    const match = key.match(/^STRATEGICREGION_(\d+)$/);
+    if (match) {
+      const regionId = parseInt(match[1], 10);
+      regions.set(regionId, value);
+    }
+  }
+  
+  return regions;
+}
+
+/**
+ * Load all localisation files from a directory
+ * @param readDir Function to read directory contents
+ * @param readFile Function to read file content
+ * @param basePath Base localisation path (e.g., /mod/localisation/japanese)
+ */
+export async function loadAllLocalisations(
+  readDir: (path: string) => Promise<{ success: boolean; data?: { name: string; isDirectory: boolean; isFile: boolean }[] }>,
+  readFile: (path: string) => Promise<{ success: boolean; data?: string }>,
+  basePath: string
+): Promise<LocalisationData> {
+  const result: LocalisationData = {
+    states: new Map(),
+    strategicRegions: new Map(),
+    countries: new Map(),
+    other: new Map(),
+  };
+  
+  // Recursive function to scan directories
+  async function scanDirectory(dirPath: string): Promise<void> {
+    const dirResult = await readDir(dirPath);
+    if (!dirResult.success || !dirResult.data) return;
+    
+    for (const entry of dirResult.data) {
+      const fullPath = `${dirPath}/${entry.name}`;
+      
+      if (entry.isDirectory) {
+        await scanDirectory(fullPath);
+      } else if (entry.isFile && entry.name.endsWith('.yml')) {
+        const fileResult = await readFile(fullPath);
+        if (fileResult.success && fileResult.data) {
+          const parsed = parseLocalisationFile(fileResult.data);
+          
+          // Extract specific data types
+          const stateNames = extractStateNames(parsed);
+          const regionNames = extractStrategicRegionNames(parsed);
+          
+          // Merge into result
+          for (const [id, name] of stateNames) {
+            result.states.set(id, name);
+          }
+          for (const [id, name] of regionNames) {
+            result.strategicRegions.set(id, name);
+          }
+          
+          // Store other keys
+          for (const [key, value] of parsed) {
+            if (!key.match(/^STATE_\d+$/) && !key.match(/^STRATEGICREGION_\d+$/)) {
+              result.other.set(key, value);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  await scanDirectory(basePath);
+  return result;
+}
+
+/**
+ * Get state name from localisation data, fallback to ID
+ */
+export function getStateName(locData: LocalisationData | null, stateId: number): string {
+  if (locData && locData.states.has(stateId)) {
+    return locData.states.get(stateId)!;
+  }
+  return `State ${stateId}`;
+}
+
+/**
+ * Get strategic region name from localisation data, fallback to ID
+ */
+export function getStrategicRegionName(locData: LocalisationData | null, regionId: number): string {
+  if (locData && locData.strategicRegions.has(regionId)) {
+    return locData.strategicRegions.get(regionId)!;
+  }
+  return `Strategic Region ${regionId}`;
+}

--- a/map-ide/src/stores/projectStore.ts
+++ b/map-ide/src/stores/projectStore.ts
@@ -4,6 +4,7 @@ import { parseDefinitionCSV, parseAdjacenciesCSV, createProvinceMaps, serializeD
 import { parseParadoxScript, ASTNode } from '../parsers/paradox/parser';
 import { serializeParadoxScript } from '../parsers/paradox/serializer';
 import { rgbToKey } from '../utils/colorUtils';
+import { LocalisationData, loadAllLocalisations, getStateName, getStrategicRegionName } from '../parsers/localisationParser';
 
 interface ProjectState {
   // Project info
@@ -30,6 +31,10 @@ interface ProjectState {
 
   // Adjacencies
   adjacencies: Adjacency[];
+
+  // Localisation
+  localisation: LocalisationData | null;
+  currentLanguage: 'japanese' | 'english';
 
   // Actions
   openProject: (rootPath: string) => Promise<void>;
@@ -63,6 +68,12 @@ interface ProjectState {
   // Mark dirty
   markDirty: () => void;
   markClean: () => void;
+
+  // Localisation
+  loadLocalisation: (language: 'japanese' | 'english') => Promise<void>;
+  setLanguage: (language: 'japanese' | 'english') => void;
+  getStateName: (stateId: number) => string;
+  getStrategicRegionName: (regionId: number) => string;
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -84,6 +95,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   aiAreas: [],
 
   adjacencies: [],
+
+  localisation: null,
+  currentLanguage: 'japanese',
 
   openProject: async (rootPath: string) => {
     set({ isLoading: true, error: null });
@@ -237,6 +251,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         isDirty: false,
         error: null,
       });
+
+      // Load localisation
+      await get().loadLocalisation('japanese');
     } catch (error) {
       set({
         isLoading: false,
@@ -257,6 +274,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       strategicRegionById: new Map(),
       aiAreas: [],
       adjacencies: [],
+      localisation: null,
       isDirty: false,
       error: null,
     });
@@ -633,6 +651,83 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
 
   markDirty: () => set({ isDirty: true }),
   markClean: () => set({ isDirty: false }),
+
+  loadLocalisation: async (language: 'japanese' | 'english') => {
+    const { project } = get();
+    if (!project) return;
+
+    try {
+      const api = window.electronAPI;
+      const basePath = `${project.rootPath}/localisation/${language}`;
+      
+      // Check if localisation directory exists
+      if (!await api.exists(basePath)) {
+        console.warn(`Localisation directory not found: ${basePath}`);
+        return;
+      }
+
+      const locData = await loadAllLocalisations(
+        async (path: string) => {
+          const result = await api.readDir(path);
+          if (result.success && result.data) {
+            return {
+              success: true,
+              data: result.data.map(entry => ({
+                name: entry.name,
+                isDirectory: entry.isDirectory,
+                isFile: entry.isFile,
+              })),
+            };
+          }
+          return { success: false };
+        },
+        async (path: string) => {
+          return api.readTextFile(path);
+        },
+        basePath
+      );
+
+      console.log(`[projectStore] Loaded localisation: ${locData.states.size} states, ${locData.strategicRegions.size} regions`);
+      set({ localisation: locData, currentLanguage: language });
+    } catch (error) {
+      console.error('Failed to load localisation:', error);
+    }
+  },
+
+  setLanguage: (language: 'japanese' | 'english') => {
+    const { currentLanguage } = get();
+    if (currentLanguage !== language) {
+      get().loadLocalisation(language);
+    }
+  },
+
+  getStateName: (stateId: number) => {
+    const { localisation, states } = get();
+    const locName = getStateName(localisation, stateId);
+    if (locName !== `State ${stateId}`) {
+      return locName;
+    }
+    // Fall back to state.name if localisation not found
+    const state = states.get(stateId);
+    if (state?.name && state.name !== `STATE_${stateId}`) {
+      return state.name;
+    }
+    return `State ${stateId}`;
+  },
+
+  getStrategicRegionName: (regionId: number) => {
+    const { localisation, strategicRegions } = get();
+    const locName = getStrategicRegionName(localisation, regionId);
+    if (locName !== `Strategic Region ${regionId}`) {
+      return locName;
+    }
+    // Fall back to region.name if localisation not found
+    const region = strategicRegions.get(regionId);
+    if (region?.name && region.name !== `STRATEGICREGION_${regionId}`) {
+      return region.name;
+    }
+    return `Region ${regionId}`;
+  },
 }));
 
 // Helper functions to parse AST to domain objects

--- a/map-ide/src/stores/settingsStore.ts
+++ b/map-ide/src/stores/settingsStore.ts
@@ -1,0 +1,39 @@
+/**
+ * Settings Store - Application settings including language
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Language, getTranslations, I18nStrings } from '../i18n';
+
+interface SettingsState {
+  language: Language;
+  t: I18nStrings;
+  
+  setLanguage: (lang: Language) => void;
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      language: 'ja', // Default to Japanese
+      t: getTranslations('ja'),
+      
+      setLanguage: (lang: Language) => {
+        set({
+          language: lang,
+          t: getTranslations(lang),
+        });
+      },
+    }),
+    {
+      name: 'map-ide-settings',
+      partialize: (state) => ({ language: state.language }),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.t = getTranslations(state.language);
+        }
+      },
+    }
+  )
+);

--- a/map-ide/src/utils/layerColors.ts
+++ b/map-ide/src/utils/layerColors.ts
@@ -1,0 +1,398 @@
+/**
+ * Layer Color Generation Utilities
+ * Generates distinct colors for States, Strategic Regions, and AI Areas
+ * Uses graph coloring approach to ensure adjacent regions have different colors
+ */
+
+import { RGB } from '../types';
+import { State, StrategicRegion, AIArea, Province } from '../types';
+
+/**
+ * Predefined color palette with high contrast colors
+ * These colors are designed to be easily distinguishable
+ */
+const COLOR_PALETTE: RGB[] = [
+  { r: 230, g: 25, b: 75 },    // Red
+  { r: 60, g: 180, b: 75 },    // Green
+  { r: 255, g: 225, b: 25 },   // Yellow
+  { r: 0, g: 130, b: 200 },    // Blue
+  { r: 245, g: 130, b: 48 },   // Orange
+  { r: 145, g: 30, b: 180 },   // Purple
+  { r: 70, g: 240, b: 240 },   // Cyan
+  { r: 240, g: 50, b: 230 },   // Magenta
+  { r: 210, g: 245, b: 60 },   // Lime
+  { r: 250, g: 190, b: 212 },  // Pink
+  { r: 0, g: 128, b: 128 },    // Teal
+  { r: 220, g: 190, b: 255 },  // Lavender
+  { r: 170, g: 110, b: 40 },   // Brown
+  { r: 255, g: 250, b: 200 },  // Beige
+  { r: 128, g: 0, b: 0 },      // Maroon
+  { r: 170, g: 255, b: 195 },  // Mint
+  { r: 128, g: 128, b: 0 },    // Olive
+  { r: 255, g: 215, b: 180 },  // Apricot
+  { r: 0, g: 0, b: 128 },      // Navy
+  { r: 128, g: 128, b: 128 },  // Grey
+  { r: 255, g: 99, b: 71 },    // Tomato
+  { r: 50, g: 205, b: 50 },    // Lime Green
+  { r: 255, g: 165, b: 0 },    // Orange
+  { r: 138, g: 43, b: 226 },   // Blue Violet
+  { r: 0, g: 191, b: 255 },    // Deep Sky Blue
+  { r: 255, g: 20, b: 147 },   // Deep Pink
+  { r: 0, g: 250, b: 154 },    // Medium Spring Green
+  { r: 218, g: 112, b: 214 },  // Orchid
+  { r: 173, g: 216, b: 230 },  // Light Blue
+  { r: 144, g: 238, b: 144 },  // Light Green
+];
+
+/**
+ * Generate a color from HSL values
+ */
+function hslToRgb(h: number, s: number, l: number): RGB {
+  let r: number, g: number, b: number;
+
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1/6) return p + (q - p) * 6 * t;
+      if (t < 1/2) return q;
+      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1/3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1/3);
+  }
+
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+/**
+ * Generate evenly distributed colors using golden ratio
+ */
+function generateDistinctColors(count: number): RGB[] {
+  const colors: RGB[] = [];
+  const goldenRatio = 0.618033988749895;
+  let hue = Math.random();
+  
+  for (let i = 0; i < count; i++) {
+    hue = (hue + goldenRatio) % 1;
+    // Use high saturation and varying lightness for visibility
+    const saturation = 0.65 + Math.random() * 0.2;
+    const lightness = 0.45 + Math.random() * 0.15;
+    colors.push(hslToRgb(hue, saturation, lightness));
+  }
+  
+  return colors;
+}
+
+/**
+ * Build adjacency graph for states based on province neighbors
+ */
+export function buildStateAdjacency(
+  states: Map<number, State>,
+  _provinces: Map<number, Province>,
+  provincePixelData: Uint8Array,
+  mapWidth: number,
+  mapHeight: number,
+  provinceByColor: Map<string, Province>
+): Map<number, Set<number>> {
+  const adjacency = new Map<number, Set<number>>();
+  
+  // Initialize adjacency sets
+  for (const stateId of states.keys()) {
+    adjacency.set(stateId, new Set());
+  }
+  
+  // Build province to state mapping
+  const provinceToState = new Map<number, number>();
+  for (const [stateId, state] of states) {
+    for (const provId of state.provinces) {
+      provinceToState.set(provId, stateId);
+    }
+  }
+  
+  // Scan pixels to find adjacent provinces
+  const step = Math.max(1, Math.floor(mapWidth / 512)); // Sample for performance
+  
+  for (let y = 0; y < mapHeight - 1; y += step) {
+    for (let x = 0; x < mapWidth - 1; x += step) {
+      const idx = (y * mapWidth + x) * 3;
+      const r1 = provincePixelData[idx];
+      const g1 = provincePixelData[idx + 1];
+      const b1 = provincePixelData[idx + 2];
+      const key1 = `${r1},${g1},${b1}`;
+      
+      // Check right neighbor
+      const idx2 = (y * mapWidth + x + 1) * 3;
+      const r2 = provincePixelData[idx2];
+      const g2 = provincePixelData[idx2 + 1];
+      const b2 = provincePixelData[idx2 + 2];
+      const key2 = `${r2},${g2},${b2}`;
+      
+      // Check bottom neighbor
+      const idx3 = ((y + 1) * mapWidth + x) * 3;
+      const r3 = provincePixelData[idx3];
+      const g3 = provincePixelData[idx3 + 1];
+      const b3 = provincePixelData[idx3 + 2];
+      const key3 = `${r3},${g3},${b3}`;
+      
+      const prov1 = provinceByColor.get(key1);
+      const prov2 = provinceByColor.get(key2);
+      const prov3 = provinceByColor.get(key3);
+      
+      if (prov1 && prov2 && prov1.id !== prov2.id) {
+        const state1 = provinceToState.get(prov1.id);
+        const state2 = provinceToState.get(prov2.id);
+        if (state1 !== undefined && state2 !== undefined && state1 !== state2) {
+          adjacency.get(state1)?.add(state2);
+          adjacency.get(state2)?.add(state1);
+        }
+      }
+      
+      if (prov1 && prov3 && prov1.id !== prov3.id) {
+        const state1 = provinceToState.get(prov1.id);
+        const state3 = provinceToState.get(prov3.id);
+        if (state1 !== undefined && state3 !== undefined && state1 !== state3) {
+          adjacency.get(state1)?.add(state3);
+          adjacency.get(state3)?.add(state1);
+        }
+      }
+    }
+  }
+  
+  return adjacency;
+}
+
+/**
+ * Graph coloring using greedy algorithm
+ * Assigns colors to nodes such that no two adjacent nodes have the same color
+ */
+export function graphColoring<T>(
+  nodes: T[],
+  adjacency: Map<T, Set<T>>,
+  colors: RGB[]
+): Map<T, RGB> {
+  const result = new Map<T, RGB>();
+  const nodeColors = new Map<T, number>();
+  
+  // Sort nodes by degree (number of neighbors) - color high-degree nodes first
+  const sortedNodes = [...nodes].sort((a, b) => {
+    const degA = adjacency.get(a)?.size ?? 0;
+    const degB = adjacency.get(b)?.size ?? 0;
+    return degB - degA;
+  });
+  
+  for (const node of sortedNodes) {
+    const neighbors = adjacency.get(node) ?? new Set();
+    const usedColors = new Set<number>();
+    
+    // Find colors used by neighbors
+    for (const neighbor of neighbors) {
+      const neighborColor = nodeColors.get(neighbor);
+      if (neighborColor !== undefined) {
+        usedColors.add(neighborColor);
+      }
+    }
+    
+    // Find first available color
+    let colorIndex = 0;
+    while (usedColors.has(colorIndex)) {
+      colorIndex++;
+    }
+    
+    // If we run out of predefined colors, generate new one
+    if (colorIndex >= colors.length) {
+      const newColors = generateDistinctColors(colorIndex - colors.length + 10);
+      colors.push(...newColors);
+    }
+    
+    nodeColors.set(node, colorIndex);
+    result.set(node, colors[colorIndex]);
+  }
+  
+  return result;
+}
+
+/**
+ * Generate colors for states with graph coloring
+ */
+export function generateStateColors(
+  states: Map<number, State>,
+  adjacency: Map<number, Set<number>>
+): Map<number, RGB> {
+  const stateIds = Array.from(states.keys());
+  return graphColoring(stateIds, adjacency, [...COLOR_PALETTE]);
+}
+
+/**
+ * Build adjacency graph for strategic regions
+ */
+export function buildStrategicRegionAdjacency(
+  regions: Map<number, StrategicRegion>,
+  states: Map<number, State>,
+  stateAdjacency: Map<number, Set<number>>
+): Map<number, Set<number>> {
+  const adjacency = new Map<number, Set<number>>();
+  
+  // Initialize
+  for (const regionId of regions.keys()) {
+    adjacency.set(regionId, new Set());
+  }
+  
+  // Build province to region mapping
+  const provinceToRegion = new Map<number, number>();
+  for (const [regionId, region] of regions) {
+    for (const provId of region.provinces) {
+      provinceToRegion.set(provId, regionId);
+    }
+  }
+  
+  // Use state adjacency to determine region adjacency
+  for (const [stateId, state] of states) {
+    const adjacentStates = stateAdjacency.get(stateId) ?? new Set();
+    
+    // Find region of this state's provinces
+    const stateRegions = new Set<number>();
+    for (const provId of state.provinces) {
+      const regionId = provinceToRegion.get(provId);
+      if (regionId !== undefined) stateRegions.add(regionId);
+    }
+    
+    // Find regions of adjacent states
+    for (const adjStateId of adjacentStates) {
+      const adjState = states.get(adjStateId);
+      if (!adjState) continue;
+      
+      for (const provId of adjState.provinces) {
+        const adjRegionId = provinceToRegion.get(provId);
+        if (adjRegionId !== undefined) {
+          for (const regionId of stateRegions) {
+            if (regionId !== adjRegionId) {
+              adjacency.get(regionId)?.add(adjRegionId);
+              adjacency.get(adjRegionId)?.add(regionId);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  return adjacency;
+}
+
+/**
+ * Generate colors for strategic regions
+ */
+export function generateStrategicRegionColors(
+  regions: Map<number, StrategicRegion>,
+  adjacency: Map<number, Set<number>>
+): Map<number, RGB> {
+  const regionIds = Array.from(regions.keys());
+  return graphColoring(regionIds, adjacency, [...COLOR_PALETTE]);
+}
+
+/**
+ * Build adjacency graph for AI areas
+ */
+export function buildAIAreaAdjacency(
+  aiAreas: AIArea[],
+  regionAdjacency: Map<number, Set<number>>
+): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  
+  // Initialize
+  for (const area of aiAreas) {
+    adjacency.set(area.name, new Set());
+  }
+  
+  // Build region to area mapping
+  const regionToArea = new Map<number, string>();
+  for (const area of aiAreas) {
+    if (area.strategicRegions) {
+      for (const regionId of area.strategicRegions) {
+        regionToArea.set(regionId, area.name);
+      }
+    }
+  }
+  
+  // Use region adjacency to determine area adjacency
+  for (const [regionId, adjacentRegions] of regionAdjacency) {
+    const areaName = regionToArea.get(regionId);
+    if (!areaName) continue;
+    
+    for (const adjRegionId of adjacentRegions) {
+      const adjAreaName = regionToArea.get(adjRegionId);
+      if (adjAreaName && adjAreaName !== areaName) {
+        adjacency.get(areaName)?.add(adjAreaName);
+        adjacency.get(adjAreaName)?.add(areaName);
+      }
+    }
+  }
+  
+  return adjacency;
+}
+
+/**
+ * Generate colors for AI areas
+ */
+export function generateAIAreaColors(
+  aiAreas: AIArea[],
+  adjacency: Map<string, Set<string>>
+): Map<string, RGB> {
+  const areaNames = aiAreas.map(a => a.name);
+  return graphColoring(areaNames, adjacency, [...COLOR_PALETTE]);
+}
+
+/**
+ * Create overlay texture for a layer
+ * Returns RGBA data with layer colors applied to provinces
+ */
+export function createLayerOverlay(
+  width: number,
+  height: number,
+  provincePixelData: Uint8Array,
+  provinceByColor: Map<string, Province>,
+  provinceToEntity: Map<number, number | string>,
+  entityColors: Map<number | string, RGB>,
+  opacity: number = 0.7
+): Uint8Array {
+  const rgba = new Uint8Array(width * height * 4);
+  const alpha = Math.round(opacity * 255);
+  
+  for (let i = 0; i < width * height; i++) {
+    const r = provincePixelData[i * 3];
+    const g = provincePixelData[i * 3 + 1];
+    const b = provincePixelData[i * 3 + 2];
+    const key = `${r},${g},${b}`;
+    
+    const province = provinceByColor.get(key);
+    if (province) {
+      const entityId = provinceToEntity.get(province.id);
+      if (entityId !== undefined) {
+        const color = entityColors.get(entityId);
+        if (color) {
+          rgba[i * 4] = color.r;
+          rgba[i * 4 + 1] = color.g;
+          rgba[i * 4 + 2] = color.b;
+          rgba[i * 4 + 3] = alpha;
+          continue;
+        }
+      }
+    }
+    
+    // Transparent if no mapping
+    rgba[i * 4 + 3] = 0;
+  }
+  
+  return rgba;
+}


### PR DESCRIPTION
- Add i18n system with Japanese/English translations
- Add layerColors utility for graph-coloring based state/region/AI area coloring
- Add localisation parser to load STATE_X and STRATEGICREGION_X names from yml files
- Update projectStore with localisation loading and name resolution functions
- Update WebGLMapCanvas with layer overlay generation using graph coloring
- Update WebGLRenderer to support layer overlay texture rendering
- Update Sidebar with selection panel showing province/state/region details
- Update Header with language toggle (JP/EN)
- Update ToolBar with Japanese labels
- Update WelcomeScreen with Japanese text
- Use distinct colors for adjacent states/regions (graph coloring algorithm)