### PR TITLE
fix(map-ide): レイヤーオーバーレイ描画とボーダー検出の改善

### DIFF
--- a/map-ide/src/components/map/WebGLMapCanvas.tsx
+++ b/map-ide/src/components/map/WebGLMapCanvas.tsx
@@ -12,6 +12,7 @@ import { rgbToKey } from '../../utils/colorUtils';
 import {
   buildStateAdjacency,
   buildStrategicRegionAdjacency,
+  buildStrategicRegionAdjacencyDirect,
   buildAIAreaAdjacency,
   generateStateColors,
   generateStrategicRegionColors,
@@ -166,60 +167,102 @@ const WebGLMapCanvas: React.FC = () => {
     renderer.updateMapTexture(bmpEditor.pixels);
   }, [bmpEditor?.pixels]);
 
-  // Generate borders and layer colors when data changes
+  // Generate layer colors when data changes (colors for fill overlay)
   useEffect(() => {
-    const renderer = rendererRef.current;
-    if (!renderer || !bmpEditor || provinces.size === 0) return;
+    if (!bmpEditor || provinces.size === 0) return;
 
-    console.log('[WebGLMapCanvas] Generating borders and colors...');
+    console.log('[WebGLMapCanvas] Generating layer colors...', {
+      statesSize: states.size,
+      regionsSize: strategicRegions.size,
+      aiAreasLength: aiAreas.length,
+      provincesSize: provinces.size,
+    });
 
-    // Build adjacency graphs and generate colors
-    if (states.size > 0) {
-      // Generate state borders
-      renderer.generateStateBorders(states, provinces, provinceByColor);
+    // Use setTimeout to avoid blocking the main thread
+    const timeoutId = setTimeout(() => {
+      // Build state adjacency for use by regions
+      let stateAdj: Map<number, Set<number>> | null = null;
       
-      // Build state adjacency and colors
-      const stateAdj = buildStateAdjacency(
-        states, provinces, bmpEditor.pixels, bmpEditor.width, bmpEditor.height, provinceByColor
-      );
-      const colors = generateStateColors(states, stateAdj);
-      setStateColors(colors);
-      console.log('[WebGLMapCanvas] Generated colors for', colors.size, 'states');
+      // Generate state colors
+      if (states.size > 0) {
+        stateAdj = buildStateAdjacency(
+          states, provinces, bmpEditor.pixels, bmpEditor.width, bmpEditor.height, provinceByColor
+        );
+        const colors = generateStateColors(states, stateAdj);
+        setStateColors(colors);
+        console.log('[WebGLMapCanvas] Generated colors for', colors.size, 'states');
+      }
       
-      // Build strategic region adjacency based on state adjacency
+      // Generate strategic region colors
       if (strategicRegions.size > 0) {
-        renderer.generateStrategicRegionBorders(strategicRegions, provinces, provinceByColor);
-        
-        const regionAdj = buildStrategicRegionAdjacency(strategicRegions, states, stateAdj);
+        // Build region adjacency - use state adjacency if available, otherwise build directly
+        let regionAdj: Map<number, Set<number>>;
+        if (stateAdj && states.size > 0) {
+          regionAdj = buildStrategicRegionAdjacency(strategicRegions, states, stateAdj);
+        } else {
+          // Build region adjacency directly from pixel data
+          regionAdj = buildStrategicRegionAdjacencyDirect(
+            strategicRegions, provinces, bmpEditor.pixels, bmpEditor.width, bmpEditor.height, provinceByColor
+          );
+        }
         const rColors = generateStrategicRegionColors(strategicRegions, regionAdj);
         setRegionColors(rColors);
         console.log('[WebGLMapCanvas] Generated colors for', rColors.size, 'strategic regions');
         
-        // Build AI area adjacency based on region adjacency
+        // Generate AI area colors
         if (aiAreas.length > 0) {
-          renderer.generateAIAreaBorders(aiAreas, strategicRegions, provinces, provinceByColor);
-          
           const aiAdj = buildAIAreaAdjacency(aiAreas, regionAdj);
           const aColors = generateAIAreaColors(aiAreas, aiAdj);
           setAIAreaColors(aColors);
           console.log('[WebGLMapCanvas] Generated colors for', aColors.size, 'AI areas');
         }
       }
-    } else {
-      // Generate strategic region borders even without states
+    }, 100);
+
+    return () => clearTimeout(timeoutId);
+  }, [bmpEditor, provinces, provinceByColor, states, strategicRegions, aiAreas]);
+
+  // Generate borders separately (can be slow)
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer || !bmpEditor || provinces.size === 0) return;
+
+    console.log('[WebGLMapCanvas] Generating borders...');
+    
+    // Defer border generation to avoid blocking UI
+    const timeoutId = setTimeout(() => {
+      if (states.size > 0) {
+        renderer.generateStateBorders(states, provinces, provinceByColor);
+      }
+      
       if (strategicRegions.size > 0) {
         renderer.generateStrategicRegionBorders(strategicRegions, provinces, provinceByColor);
       }
-
-      // Generate AI area borders
+      
       if (aiAreas.length > 0) {
         renderer.generateAIAreaBorders(aiAreas, strategicRegions, provinces, provinceByColor);
       }
-    }
+      
+      console.log('[WebGLMapCanvas] Borders generated');
+    }, 500); // Delay border generation
+
+    return () => clearTimeout(timeoutId);
   }, [bmpEditor, provinces, provinceByColor, states, strategicRegions, aiAreas]);
 
   // Generate layer overlay when active layer or colors change
   useEffect(() => {
+    console.log('[WebGLMapCanvas] Layer overlay effect triggered:', {
+      activeLayer,
+      hasEditor: !!bmpEditor,
+      provincesSize: provinces.size,
+      statesSize: states.size,
+      stateColorsSize: stateColors.size,
+      regionsSize: strategicRegions.size,
+      regionColorsSize: regionColors.size,
+      aiAreasLength: aiAreas.length,
+      aiAreaColorsSize: aiAreaColors.size,
+    });
+    
     if (!bmpEditor || provinces.size === 0) {
       setLayerOverlay(null);
       return;
@@ -229,6 +272,14 @@ const WebGLMapCanvas: React.FC = () => {
     let provinceToEntity: Map<number, number | string> | null = null;
     let entityColors: Map<number | string, RGB> | null = null;
 
+    console.log('[WebGLMapCanvas] Checking layer conditions:', {
+      activeLayer,
+      statesHasData: states.size > 0,
+      stateColorsHasData: stateColors.size > 0,
+      regionsHasData: strategicRegions.size > 0,
+      regionColorsHasData: regionColors.size > 0,
+    });
+    
     if (activeLayer === 'states' && stateColors.size > 0) {
       provinceToEntity = new Map();
       // Prefer province.stateId to ensure consistency even if state definitions are out of sync
@@ -291,6 +342,11 @@ const WebGLMapCanvas: React.FC = () => {
       entityColors = new Map(aiAreaColors) as Map<number | string, RGB>;
     }
 
+    console.log('[WebGLMapCanvas] Layer mapping:', {
+      provinceToEntitySize: provinceToEntity?.size ?? 0,
+      entityColorsSize: entityColors?.size ?? 0,
+    });
+
     if (provinceToEntity && entityColors && provinceToEntity.size > 0 && entityColors.size > 0) {
       overlay = createLayerOverlay(
         bmpEditor.width,
@@ -299,9 +355,11 @@ const WebGLMapCanvas: React.FC = () => {
         provinceByColor,
         provinceToEntity,
         entityColors,
-        1.0 // opacity
+        0.6 // opacity - slightly transparent to see province colors underneath
       );
-      console.log('[WebGLMapCanvas] Created layer overlay for', activeLayer);
+      console.log('[WebGLMapCanvas] Created layer overlay for', activeLayer, 'size:', overlay.length);
+    } else {
+      console.log('[WebGLMapCanvas] Skipping overlay creation - missing data');
     }
 
     setLayerOverlay(overlay);

--- a/map-ide/src/components/panels/CountryColorsPanel.tsx
+++ b/map-ide/src/components/panels/CountryColorsPanel.tsx
@@ -133,7 +133,13 @@ const CountryColorsPanel: React.FC = () => {
       }
     }
     
-    return result.sort((a, b) => a.tag.localeCompare(b.tag));
+    // Deduplicate by tag, keeping the last occurrence
+    const deduped = new Map<string, CountryColor>();
+    for (const entry of result) {
+      deduped.set(entry.tag, entry);
+    }
+    
+    return Array.from(deduped.values()).sort((a, b) => a.tag.localeCompare(b.tag));
   };
 
   // Handle edit start

--- a/map-ide/src/core/WebGLRenderer.ts
+++ b/map-ide/src/core/WebGLRenderer.ts
@@ -110,7 +110,7 @@ void main() {
   vec2 translated = scaled + u_translation;
   vec2 clipSpace = (translated / u_resolution) * 2.0 - 1.0;
   gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
-  gl_PointSize = 2.0;
+  gl_PointSize = 3.0;
 }
 `;
 
@@ -441,12 +441,21 @@ export class WebGLRenderer {
    * Upload layer overlay data (RGBA)
    */
   uploadLayerOverlay(overlayData: Uint8Array | null): void {
+    console.log('[WebGLRenderer] uploadLayerOverlay called:', {
+      hasData: !!overlayData,
+      dataLength: overlayData?.length,
+      mapWidth: this.mapWidth,
+      mapHeight: this.mapHeight,
+      expectedLength: this.mapWidth * this.mapHeight * 4,
+    });
+    
     if (!this.mapWidth || !this.mapHeight) return;
     
     if (this.useWebGL && this.gl && this.layerTexture && overlayData) {
       const gl = this.gl;
       gl.bindTexture(gl.TEXTURE_2D, this.layerTexture);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, this.mapWidth, this.mapHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, overlayData);
+      console.log('[WebGLRenderer] Layer overlay texture uploaded to WebGL');
     }
   }
 
@@ -616,17 +625,29 @@ export class WebGLRenderer {
     
     const width = this.mapWidth;
     const height = this.mapHeight;
-    const step = Math.max(1, Math.floor(width / 1024));
+    // Use step=1 for full resolution border detection
+    // This ensures continuous border lines rather than dotted points
+    const step = 1;
     
     for (let y = 0; y < height - 1; y += step) {
       for (let x = 0; x < width - 1; x += step) {
-        const color1 = this.getPixelColor(x, y);
-        const color2 = this.getPixelColor(x + 1, y);
-        const color3 = this.getPixelColor(x, y + 1);
+        const idx1 = (y * width + x) * 3;
+        const r1 = this.provincePixelData[idx1];
+        const g1 = this.provincePixelData[idx1 + 1];
+        const b1 = this.provincePixelData[idx1 + 2];
+        const key1 = `${r1},${g1},${b1}`;
         
-        const key1 = `${color1.r},${color1.g},${color1.b}`;
-        const key2 = `${color2.r},${color2.g},${color2.b}`;
-        const key3 = `${color3.r},${color3.g},${color3.b}`;
+        const idx2 = (y * width + x + 1) * 3;
+        const r2 = this.provincePixelData[idx2];
+        const g2 = this.provincePixelData[idx2 + 1];
+        const b2 = this.provincePixelData[idx2 + 2];
+        const key2 = `${r2},${g2},${b2}`;
+        
+        const idx3 = ((y + 1) * width + x) * 3;
+        const r3 = this.provincePixelData[idx3];
+        const g3 = this.provincePixelData[idx3 + 1];
+        const b3 = this.provincePixelData[idx3 + 2];
+        const key3 = `${r3},${g3},${b3}`;
         
         const p1 = provinceByColor.get(key1);
         const p2 = provinceByColor.get(key2);
@@ -638,6 +659,7 @@ export class WebGLRenderer {
       }
     }
     
+    console.log('[WebGLRenderer] Detected', borderPixels.length, 'border pixels');
     return borderPixels;
   }
 
@@ -1030,7 +1052,7 @@ export class WebGLRenderer {
         return;
     }
     
-    const pointSize = Math.max(1, 2 / state.zoom);
+    const pointSize = Math.max(2, 3 / state.zoom);
     
     for (const [, segment] of borders) {
       const [r, g, b, a] = segment.color;
@@ -1038,7 +1060,7 @@ export class WebGLRenderer {
       
       const points = segment.points;
       for (let i = 0; i < points.length; i += 2) {
-        ctx.fillRect(points[i], points[i + 1], pointSize, pointSize);
+        ctx.fillRect(points[i] - pointSize/2, points[i + 1] - pointSize/2, pointSize, pointSize);
       }
     }
   }

--- a/map-ide/src/utils/layerColors.ts
+++ b/map-ide/src/utils/layerColors.ts
@@ -235,6 +235,85 @@ export function generateStateColors(
 }
 
 /**
+ * Build adjacency graph for strategic regions directly from pixel data
+ * Used when state data is not available
+ */
+export function buildStrategicRegionAdjacencyDirect(
+  regions: Map<number, StrategicRegion>,
+  _provinces: Map<number, Province>,
+  provincePixelData: Uint8Array,
+  mapWidth: number,
+  mapHeight: number,
+  provinceByColor: Map<string, Province>
+): Map<number, Set<number>> {
+  const adjacency = new Map<number, Set<number>>();
+  
+  // Initialize adjacency sets
+  for (const regionId of regions.keys()) {
+    adjacency.set(regionId, new Set());
+  }
+  
+  // Build province to region mapping
+  const provinceToRegion = new Map<number, number>();
+  for (const [regionId, region] of regions) {
+    for (const provId of region.provinces) {
+      provinceToRegion.set(provId, regionId);
+    }
+  }
+  
+  // Scan pixels to find adjacent provinces
+  const step = Math.max(1, Math.floor(mapWidth / 512));
+  
+  for (let y = 0; y < mapHeight - 1; y += step) {
+    for (let x = 0; x < mapWidth - 1; x += step) {
+      const idx = (y * mapWidth + x) * 3;
+      const r1 = provincePixelData[idx];
+      const g1 = provincePixelData[idx + 1];
+      const b1 = provincePixelData[idx + 2];
+      const key1 = `${r1},${g1},${b1}`;
+      
+      // Check right neighbor
+      const idx2 = (y * mapWidth + x + 1) * 3;
+      const r2 = provincePixelData[idx2];
+      const g2 = provincePixelData[idx2 + 1];
+      const b2 = provincePixelData[idx2 + 2];
+      const key2 = `${r2},${g2},${b2}`;
+      
+      // Check bottom neighbor
+      const idx3 = ((y + 1) * mapWidth + x) * 3;
+      const r3 = provincePixelData[idx3];
+      const g3 = provincePixelData[idx3 + 1];
+      const b3 = provincePixelData[idx3 + 2];
+      const key3 = `${r3},${g3},${b3}`;
+      
+      const prov1 = provinceByColor.get(key1);
+      const prov2 = provinceByColor.get(key2);
+      const prov3 = provinceByColor.get(key3);
+      
+      if (prov1 && prov2 && prov1.id !== prov2.id) {
+        const region1 = provinceToRegion.get(prov1.id);
+        const region2 = provinceToRegion.get(prov2.id);
+        if (region1 !== undefined && region2 !== undefined && region1 !== region2) {
+          adjacency.get(region1)?.add(region2);
+          adjacency.get(region2)?.add(region1);
+        }
+      }
+      
+      if (prov1 && prov3 && prov1.id !== prov3.id) {
+        const region1 = provinceToRegion.get(prov1.id);
+        const region3 = provinceToRegion.get(prov3.id);
+        if (region1 !== undefined && region3 !== undefined && region1 !== region3) {
+          adjacency.get(region1)?.add(region3);
+          adjacency.get(region3)?.add(region1);
+        }
+      }
+    }
+  }
+  
+  return adjacency;
+}
+
+/**
  * Build adjacency graph for strategic regions
  */
 export function buildStrategicRegionAdjacency(
@@ -369,6 +448,10 @@ export function createLayerOverlay(
   const rgba = new Uint8Array(width * height * 4);
   const alpha = Math.round(opacity * 255);
   
+  let coloredPixels = 0;
+  let unmappedProvinces = 0;
+  let noEntityMapping = 0;
+  
   for (let i = 0; i < width * height; i++) {
     const r = provincePixelData[i * 3];
     const g = provincePixelData[i * 3 + 1];
@@ -385,14 +468,29 @@ export function createLayerOverlay(
           rgba[i * 4 + 1] = color.g;
           rgba[i * 4 + 2] = color.b;
           rgba[i * 4 + 3] = alpha;
+          coloredPixels++;
           continue;
         }
+      } else {
+        noEntityMapping++;
       }
+    } else {
+      unmappedProvinces++;
     }
     
     // Transparent if no mapping
     rgba[i * 4 + 3] = 0;
   }
+  
+  console.log('[createLayerOverlay] Stats:', {
+    totalPixels: width * height,
+    coloredPixels,
+    unmappedProvinces,
+    noEntityMapping,
+    provinceByColorSize: provinceByColor.size,
+    provinceToEntitySize: provinceToEntity.size,
+    entityColorsSize: entityColors.size,
+  });
   
   return rgba;
 }


### PR DESCRIPTION
## 概要
States🟠、Strategic Regions🔵、AI Areas🟣 モードでのレイヤー表示の問題を修正

## 変更内容

### バグ修正
- **CountryColorsPanel**: 重複キー警告を修正（DEUなどの重複エントリを除去）
- **レイヤーオーバーレイ**: States/Regions/AI Areasモードで塗りつぶしが表示されない問題を修正

### パフォーマンス改善
- 色生成とボーダー生成を別々のuseEffectに分離
- setTimeoutを使用してメインスレッドをブロックしないように改善
- ボーダー検出を全ピクセルスキャンに変更（連続した線を描画）

### 新機能
- `buildStrategicRegionAdjacencyDirect`: statesデータなしでも直接隣接関係を構築
- デバッグログを追加（コンソールでレイヤーオーバーレイの生成状況を確認可能）

## 技術的詳細
- WebGLRenderer: ボーダー検出のstepを1に変更、点サイズを3.0に増加
- layerColors: createLayerOverlayに統計ログを追加
- WebGLMapCanvas: useEffectの分離とsetTimeoutによる非同期処理