### PR TITLE
feat: 第二次エミュー戦争コンテンツ全実装 (HRH抵抗勢力 + AST支援 + AI編制)

### DIFF
--- a/CONTENT_PLAN_second_emu_war.md
+++ b/CONTENT_PLAN_second_emu_war.md
@@ -1,284 +1,429 @@
-# 第二次エミュー戦争 コンテンツプラン
+# 第二次エミュー戦争 コンテンツプラン（実装済み版）
 ## ブランチ: `feature/second-emu-war`
-## 作成日: 2026-05-22
+## 作成日: 2026-05-22 / 最終更新: 2026-05-22
 
 ---
 
 ## 概要・世界観
 
-「第二次エミュー戦争」は、**エミュー帝国(AUS)** の勢力拡大に対し、
-**オーストラリア連邦(AST)** と **ハットリバー公国(HRH)** が共同戦線を張り、
-さらに本国イギリス **(GBR)** の介入・思惑が絡む多角的な紛争シナリオ。
+「第二次エミュー戦争」は、**エミュー帝国(AUS)** の支配する西オーストラリアで、
+**ハットリバー公国(HRH)** が本土抵抗勢力として蜂起し、
+タスマニアを拠点とする **オーストラリア連邦(AST)** が支援に駆けつけ、
+さらに本国 **イギリス(GBR)** の思惑が絡む多角的な紛争シナリオ。
 
 ### 史実ベース（バカ世界地図解釈）
 | 要素 | 史実 | 本MODでの解釈 |
 |------|------|--------------|
 | 大エミュー戦争(1932) | オーストラリア軍がエミュー駆除作戦に失敗 | エミューが勝利し「エミュー帝国」を樹立 |
-| ハットリバー公国 | 1970年にオーストラリアから独立宣言 | エミューに領土を奪われた亡命政権 |
-| イギリスとオーストラリア | コモンウェルス関係 | エミュー問題への干渉・コモンウェルス維持 vs 放棄の駆け引き |
+| ハットリバー公国 | 1970年にオーストラリアから独立宣言した農場主 | 州1097を本拠地とする**本土抵抗勢力**。AUSに囲まれた孤立した抵抗組織 |
+| イギリスとオーストラリア | コモンウェルス関係 | エミュー問題への干渉・コモンウェルス維持 vs 独立外交の駆け引き |
+
+### HRHの正確な位置づけ
+- **本土抵抗勢力**（亡命政権ではない）
+- 拠点: 州1097（ハットリバー本拠地、HRH所有・core）
+- 目標: 州884（西オーストラリア、AUS所有）を奪取して西海岸回廊を確保
+- ASTの首都タスマニア(州518)とは海を隔てた関係 → ASTは海軍上陸が主要手段
 
 ---
 
 ## 関係国タグ一覧
 
-| タグ | 国名 | 役割 |
-|------|------|------|
-| `AUS` | エミュー帝国 | 今回の主な敵対勢力 |
-| `AST` | オーストラリア連邦 | 主人公側・反エミュー連合の中核 |
-| `HRH` | ハットリバー公国 | 亡命政権・AST側盟友 |
-| `GBR` | イギリス | 第三勢力・コモンウェルス問題で介入 |
+| タグ | 国名 | 役割 | 拠点 |
+|------|------|------|------|
+| `AUS` | エミュー帝国 | 主敵 | 西オーストラリア全域 |
+| `AST` | オーストラリア連邦 | 支援国・参戦勢力 | タスマニア（州518） |
+| `HRH` | ハットリバー公国 | 本土抵抗勢力・主人公側 | ハットリバー（州1097） |
+| `GBR` | イギリス | 第三勢力・コモンウェルス問題 | ロンドン |
 
 ---
 
-## 新規ファイル構成
+## 実装済みファイル構成
 
 ```
 bakasekai/
 ├── events/
-│   ├── second_emu_war_events.txt       # 第二次エミュー戦争イベント群(AST/HRH視点)
-│   ├── second_emu_war_gbr_events.txt   # イギリス介入イベント群
-│   └── second_emu_war_aus_events.txt   # エミュー帝国側反応イベント群
+│   └── second_emu_war_ast_support_events.txt  ✅ 実装済み
+│       # Namespace: sew_support / sew_aus / sew_gbr
+│       # 10イベント: sew_support.1〜8, sew_aus.1, sew_gbr.1
+│
 ├── common/
 │   ├── national_focus/
-│   │   ├── AST_second_emu_war.txt      # AST用フォーカスツリー拡張
-│   │   ├── HRH_second_emu_war.txt      # HRH用フォーカスツリー拡張
-│   │   └── GBR_emu_intervention.txt    # GBR介入フォーカス(小規模)
+│   │   └── AST_second_emu_war.txt             ✅ 実装済み
+│   │       # focus_tree id = ast_second_emu_war_focus
+│   │       # 13フォーカス（3ブランチ+参戦+戦後）
+│   │
 │   ├── ideas/
-│   │   └── second_emu_war_ideas.txt    # 新国家精神・国家方針
-│   └── decisions/
-│       └── second_emu_war_decisions.txt # 関連ディシジョン
-└── localisation/
-    └── japanese/bakasekai/
-        └── second_emu_war_l_japanese.yml
+│   │   └── second_emu_war_ideas.txt           ✅ 実装済み
+│   │       # 16国家精神（AST×7 / HRH×6 / AUS×2 / GBR×1）
+│   │
+│   ├── ai_templates/
+│   │   └── sew_templates.txt                  ✅ 実装済み
+│   │       # 9テンプレート（HRH×3 / AST×3 / AUS×3）
+│   │
+│   ├── ai_strategy/
+│   │   └── sew_strategies.txt                 ✅ 実装済み
+│   │       # 19ストラテジー（HRH×6 / AST×8 / AUS×5）
+│   │
+│   └── ai_strategy_plans/
+│       └── sew_strategy_plans.txt             ✅ 実装済み
+│           # 3プラン（HRH×1 / AST×2）
+│
+└── localisation/japanese/bakasekai/
+    └── second_emu_war_l_japanese.yml          ✅ 実装済み
+        # 全コンテンツの日本語テキスト
 ```
 
 ---
 
-## フォーカスツリー設計
-
-### AST（オーストラリア連邦）拡張ツリー
-**フォーカスツリーID**: `ast_second_emu_war_focus`（既存`australia.txt`への追加も検討）
+## 既存コンテンツとの接続フロー
 
 ```
-[AST_sew_root] 第二次エミュー戦争への備え
+【HRH既存フォーカスツリー】
+HRH_focus_1 → focus_2(TECH_1) → focus_3 → focus_4/focus_4A
+    └→ focus_A2 → focus_A3 → focus_AB3
+    └→ focus_A4 → focus_5(TECH_2: militia+irregular解放)
+                    └→ focus_6(HRH_recapture_started セット)
+
+【既存ディシジョン】
+HRH_recapture_neighborhood (30日, 70%成功率)
+    └→ 州884をHRHへ移譲
+    └→ フラグ: HRH_recapture_success セット
+    └→ news_event: HRH.1
+
+【既存イベント】
+HRH_recapture_states.1 (HRH視点) → HRH_recapture_states.2 (AST視点)
+    └→ create_faction = Bokka_Alliance
+    └→ add_to_faction = HRH
+    └→ ★★★ sew_support.1 を HRH に送信 ★★★（← 新コンテンツへの接続点）
+
+【新コンテンツ起動】
+sew_support.1 (HRH): 支援要請を出すか選択
+    └→ option.a → AST に sew_support.2 を送信
+```
+
+---
+
+## イベント設計（実装済み）
+
+### Namespace: `sew_support`（HRH/AST支援交渉）
+
+| ID | 受信国 | タイトル | 概要 |
+|----|--------|---------|------|
+| `sew_support.1` | HRH | ASTへの支援要請 | 支援要請を出すか選択。option.a → AST に sew_support.2 送信 |
+| `sew_support.2` | AST | ハットリバーからの要請 | 4択: a)装備支援 / b)顧問派遣 / c)参戦確認 / d)拒否 |
+| `sew_support.3` | HRH | ASTの拒否通知 | HRH_sew_alone_spirit 獲得 |
+| `sew_support.4` | HRH | 物資到着報告 | AST装備到着を確認、AST に sew_support.6 送信 |
+| `sew_support.5` | AST | 参戦最終確認 | a)即時宣戦(declare_war_on AUS) / b)60日後再確認 |
+| `sew_support.6` | AST | 追加支援要請受信 | 継続支援の確認イベント |
+| `sew_support.7` | HRH | AST参戦通知 | war_support +0.15 |
+| `sew_support.8` | AST | 英国参観武官 | a)AST_sew_british_liaison 取得 / b)AST_sew_independence_spirit 取得 |
+
+### Namespace: `sew_aus`（AUS反応）
+
+| ID | 受信国 | タイトル | 概要 |
+|----|--------|---------|------|
+| `sew_aus.1` | AUS | AST参戦への対応 | AUS_sew_war_footing または AUS_sew_defensive_posture 取得 |
+
+### Namespace: `sew_gbr`（GBR対応）
+
+| ID | 受信国 | タイトル | 概要 |
+|----|--------|---------|------|
+| `sew_gbr.1` | GBR | コモンウェルス緊急対応 | コモンウェルス介入・仲介・傍観の3択 |
+
+---
+
+## ASTフォーカスツリー設計（実装済み）
+
+**focus_tree id**: `ast_second_emu_war_focus`  
+**解禁条件**: `is_in_faction_with = HRH` または `has_country_flag = AST_sew_hrh_contacted`、かつ `HRH.has_country_flag = HRH_recapture_success`
+
+```
+[AST_sew_respond_to_hrh] x=7,y=0  HRH連絡・支援意思表示
+    │                   (→ sew_support.1 を HRH に送信)
     │
-    ├── [AST_sew_recall_emu_war]  大エミュー戦争の教訓
-    │       └── [AST_sew_new_doctrine]  対エミュー戦闘教義
-    │               └── [AST_sew_anti_emu_unit]  エミュー駆除部隊創設
+    ├── [左ブランチ: 物資・装備支援]
+    │   [AST_sew_supply_hrh] x=4,y=1  装備3000+支援300をHRHに
+    │       ├── [AST_sew_artillery_support] x=3,y=2  砲兵装備400+研究ボーナス
+    │       └── [AST_sew_naval_support] x=5,y=2  海上補給路確保(idea付与)
     │
-    ├── [AST_sew_hrh_alliance]  ハットリバーと手を組む
-    │       └── [AST_sew_combined_arms]  合同作戦計画
-    │               └── [AST_sew_liberation_of_west]  西部解放作戦
+    ├── [中央ブランチ: 軍事顧問・合同作戦]
+    │   [AST_sew_send_advisors] x=7,y=1  HRH_sew_ast_advisors idea+経験値
+    │       ├── [AST_sew_joint_training] x=6,y=2  HRHにドクトリン研究ボーナス×2
+    │       └── [AST_sew_combined_ops_plan] x=8,y=2  HRH_sew_combined_ops_bonus(戦時限定)
     │
-    ├── [AST_sew_gbr_request]  英国への援助要請
-    │       ├── [AST_sew_gbr_accepted]  英国軍の上陸支援(GBR友好時)
-    │       └── [AST_sew_gbr_rejected]  独力で戦う(GBR拒否時)
+    ├── [右ブランチ: 英国外交]
+    │   [AST_sew_contact_gbr] x=10,y=1  sew_gbr.1 を GBR に送信
+    │       ├── [AST_sew_gbr_military_aid] x=9,y=2  GBR装備2000+AST_sew_british_support_active
+    │       └── [AST_sew_gbr_independent] x=11,y=2  ★相互排他★ 独立路線(安定度+0.05)
     │
-    └── [AST_sew_total_war]  総力戦宣言
-            └── [AST_sew_final_push]  最終攻勢
-                    └── [AST_sew_victory]  エミュー帝国の解体
+    └── [合流: 参戦・戦後]
+        [AST_sew_mobilize] x=7,y=3  動員(左右どちらか経由後)
+            └── [AST_sew_declare_war] x=7,y=4  join HRH + declare_war AUS
+                ├── [AST_sew_post_war_hrh_recognition] x=5,y=5  HRH自治承認
+                ├── [AST_sew_reclaim_west] x=7,y=5  州879-885をASTコアに追加
+                └── [AST_sew_gbr_thank_you] x=9,y=5  英国感謝外交(GBR支援ルート限定)
 ```
 
 ---
 
-### HRH（ハットリバー公国）拡張ツリー
-**既存ツリーへの追加フォーカス**
+## 国家精神設計（実装済み）
 
+### AST用（7件）
+| ID | 効果 |
+|----|------|
+| `AST_sew_war_mobilization` | 徴兵+0.05、陸軍経験値+0.10 |
+| `AST_sew_war_preparation` | 工場効率+0.10、PP-20/月 |
+| `AST_sew_british_liaison` | 研究速度+0.05、英国関係良化 |
+| `AST_sew_british_support_active` | 装備受領ボーナス |
+| `AST_sew_independence_spirit` | 安定度+0.05、戦意+0.05 |
+| `AST_sew_western_coast_supply_route` | 海上補給路確保(HRH支援効率UP) |
+| `AST_sew_west_reclaimed` | 西部再統合記念、安定度+0.10 |
+
+### HRH用（6件）
+| ID | 効果 |
+|----|------|
+| `HRH_sew_ast_equipped` | 歩兵攻撃+0.10、irregular攻撃+0.15 |
+| `HRH_sew_ast_advisors` | 組織力回復+0.05、ドクトリン研究速度+0.10 |
+| `HRH_sew_ast_full_support` | 戦意+0.15、回復速度+0.10 |
+| `HRH_sew_combined_ops_bonus` | 合同作戦中の攻撃力ボーナス |
+| `HRH_sew_alone_spirit` | 孤立無援、戦意のみ+0.10（デバフあり） |
+| `HRH_sew_ast_recognition` | 戦後自治承認、安定度+0.15 |
+
+### AUS用（2件）
+| ID | 効果 |
+|----|------|
+| `AUS_sew_war_footing` | 徴兵+0.05、陸軍士気+0.10 |
+| `AUS_sew_defensive_posture` | 防御戦闘力+0.15 |
+
+### GBR用（1件）
+| ID | 効果 |
+|----|------|
+| `GBR_sew_commonwealth_duty` | コモンウェルス義務遂行精神 |
+
+---
+
+## AI師団編制テンプレート設計（実装済み）
+
+### HRH（3テンプレート）
 ```
-[HRH_focus_8]（既存：牧歌同盟の結成）の後続
-    │
-    ├── [HRH_sew_rearm]         再武装計画
-    │       └── [HRH_sew_militia_elite]  精鋭民兵団
-    │
-    ├── [HRH_sew_legitimacy]    正統性の宣言
-    │       └── [HRH_sew_gbr_recognition] GBRへの承認要請
-    │               ├── [HRH_sew_commonwealth_member] コモンウェルス加盟
-    │               └── [HRH_sew_full_independence]  完全独立路線
-    │
-    └── [HRH_sew_intel_network]  諜報網構築
-            └── [HRH_sew_sabotage]  エミュー帝国内部工作
+HRH_sew_infantry (role=infantry, upgrade_prio×3)
+  ├─ HRH_irregular_core: irregular×4+militia×3, recon+engineer
+  │     └→ replace_with HRH_irregular_reinforced (at 80% match)
+  ├─ HRH_irregular_reinforced: irregular×5+militia×3+infantry×1, +artillery
+  │     └→ replace_with HRH_regular_combined (at 90% match)
+  │     ※ HRH_sew_ast_equipped idea取得でupgrade_prio×3
+  └─ HRH_regular_combined: infantry×6+irregular×3, recon+engineer+artillery+anti_tank
+       ※ HRH_sew_ast_advisors idea取得でupgrade_prio×4
+
+HRH_sew_garrison (role=garrison, upgrade_prio×2)
+  └─ HRH_garrison_militia: militia×4
+
+HRH_sew_suppression (role=suppression, upgrade_prio×1)
+  └─ HRH_suppression_light: irregular×3+militia×2
+```
+
+### AST（3テンプレート）
+```
+AST_sew_infantry (role=infantry, upgrade_prio×3)
+  ├─ AST_standard_infantry: infantry×9, engineer+artillery
+  │     └→ replace_with AST_assault_infantry (at 90% match)
+  └─ AST_assault_infantry: infantry×9+anti_tank_brigade×1, +anti_tank+recon
+       ※ AST_sew_war_mobilization idea取得でupgrade_prio×3
+
+AST_sew_marines (role=marines, upgrade_prio×2)
+  └─ AST_marine_landing: marine×4+infantry×2, engineer+recon
+       ※ AST_sew_declare_war完了でupgrade_prio×4
+
+AST_sew_garrison (role=garrison, upgrade_prio×1)
+  └─ AST_garrison_standard: infantry×4
+```
+
+### AUS（3テンプレート）
+```
+AUS_sew_infantry (role=infantry, upgrade_prio×3)
+  ├─ AUS_emu_standard: infantry×9+cavalry×1（哨戒用）, recon+engineer
+  │     └→ replace_with AUS_emu_wartime (at 90% match)
+  └─ AUS_emu_wartime: infantry×9+militia×2, recon+engineer+artillery+anti_tank
+       ※ AUS_sew_war_footing idea取得でupgrade_prio×5
+
+AUS_sew_garrison (role=garrison, upgrade_prio×2)
+  └─ AUS_garrison_wide: infantry×4+militia×2（広大な本土の広域維持）
+
+AUS_sew_suppression (role=suppression, upgrade_prio×1)
+  └─ AUS_suppression_cavalry: cavalry×4
 ```
 
 ---
 
-### GBR（イギリス）介入フォーカス（小規模）
+## AI戦略ストラテジー設計（実装済み）
 
-```
-[GBR_emu_crisis] エミュー危機への対応
-    ├── [GBR_emu_intervene]     軍事介入 → ASTへの軍事支援
-    ├── [GBR_emu_mediate]       調停外交 → 停戦交渉
-    └── [GBR_emu_abandon]       傍観      → コモンウェルス弱体化
-```
+### HRH（6ストラテジー）
 
----
+| ストラテジーID | enable条件 | 主な内容 |
+|----------------|-----------|---------|
+| `HRH_sew_peacetime_force` | original_tag=HRH, has_war=no | infantry=90, armor/cavalry=-100, garrison=5 |
+| `HRH_sew_wartime_force` | original_tag=HRH, has_war_with=AUS | infantry=85, garrison=10, 歩兵装備+60, 砲兵+20 |
+| `HRH_sew_research_priority` | original_tag=HRH | infantry_weapons+40, support+30, land_doctrine+20, naval=-80 |
+| `HRH_sew_diplomacy_support_ast` | HRH, AST存在 | befriend AST+200, alliance AST+100 |
+| `HRH_sew_diplomacy_oppose_aus` | HRH, AUS存在 | antagonize AUS+100 |
+| `HRH_sew_production_priority` | original_tag=HRH | arms_factory+100, infrastructure+20 |
+| `HRH_sew_supplied_by_ast` | HRH_sew_ast_equipped取得時 | 歩兵装備生産-20（AST支給分を相殺） |
 
-## イベントシナリオ設計
+### AST（8ストラテジー）
 
-### Namespace: `second_emu_war`（AST/HRH視点）
+| ストラテジーID | enable条件 | 主な内容 |
+|----------------|-----------|---------|
+| `AST_sew_base_force` | original_tag=AST | infantry=75, marines=5, garrison=10 |
+| `AST_sew_wartime_force` | AST, has_war_with=AUS | marines=15, 海軍convoy+15, 歩兵装備+50 |
+| `AST_sew_research_priority` | original_tag=AST | naval+35, infantry+30, support+25 |
+| `AST_sew_diplomacy_hrh` | HRH.has_country_flag=HRH_recapture_success | befriend HRH+200, support HRH+100 |
+| `AST_sew_diplomacy_gbr` | GBR存在 | befriend GBR+50 |
+| `AST_sew_diplomacy_oppose_aus` | AUS存在 | antagonize AUS+150 |
+| `AST_sew_supply_hrh_ai` | HRH戦争中, AST平時 | support HRH+150（自動支援意欲） |
+| `AST_sew_area_priority` | AST, has_war_with=AUS | oceania+200, pacific+100, europe=-100, naval_invasion+200 |
 
-| ID | タイトル | 発火条件 | 概要 |
-|----|---------|---------|------|
-| `second_emu_war.1` | 第二次エミュー戦争の予兆 | AST, fire_only_once, date>1937.1.1 | エミュー帝国の膨張を察知したAST首脳部の緊急会議 |
-| `second_emu_war.2` | 国境侵犯事件 | AST, AUSと隣接後N月 | AUSの小部隊がAST領土内に侵入 |
-| `second_emu_war.3` | ハットリバーからの救援要請 | AST, HRH存在時 | HRHがASTに共同作戦を要請 |
-| `second_emu_war.4` | 英国大使の訪問 | AST, GBR健在時 | GBRがコモンウェルス維持を条件に援助を申し出る |
-| `second_emu_war.5` | 砂漠の罠 | AST, has_war=AUS | エミュー軍が砂漠地帯に誘引作戦を展開 |
-| `second_emu_war.6` | ハットリバー民兵の奮闘 | HRH, has_war=AUS | HRH民兵が英雄的な防衛戦を展開 |
-| `second_emu_war.7` | 開戦宣言 | AST, フォーカス完了時 | 正式な対エミュー帝国宣戦布告 |
-| `second_emu_war.8` | 西部戦線の突破 | AST, 特定州占領後 | 西オーストラリア州の一部解放成功 |
-| `second_emu_war.9` | エミュー皇帝の演説 | AUS視点でも通知 | エミュー帝国が「聖戦」を宣言 |
-| `second_emu_war.10` | 停戦か継続か | AST, AUSの首都占領後 | 戦後処理の分岐点 |
+### AUS（5ストラテジー）
 
----
-
-### Namespace: `sew_gbr`（イギリス介入イベント）
-
-| ID | タイトル | 発火条件 | 概要 |
-|----|---------|---------|------|
-| `sew_gbr.1` | エミュー問題とコモンウェルス | GBR, date>1937.3.1 | 議会でオーストラリア問題が議題に |
-| `sew_gbr.2` | オーストラリアからの支援要請 | GBR, AST発火後 | ASTのSOSを受け取ったGBR |
-| `sew_gbr.3` | 軍事顧問団の派遣 | GBR, 支援選択後 | GBR軍事顧問がAST軍を指導 |
-| `sew_gbr.4` | コモンウェルス会議の招集 | GBR, 調停選択後 | カナダ・NZも巻き込んだ外交交渉 |
-| `sew_gbr.5` | 英国の撤退 | GBR, 傍観選択後 | コモンウェルス関係の見直し通告 |
+| ストラテジーID | enable条件 | 主な内容 |
+|----------------|-----------|---------|
+| `AUS_sew_base_force` | original_tag=AUS | infantry=80, garrison=8, cavalry=3, armor=-80 |
+| `AUS_sew_wartime_force` | AUS, 戦争中+war_footing | infantry=85, garrison=10, 歩兵装備+60 |
+| `AUS_sew_defend_west` | AUS, has_war_with=HRH, 884未制御 | oceania+300, conquer HRH+100 |
+| `AUS_sew_research_priority` | original_tag=AUS | infantry_weapons+40, land_doctrine+25 |
+| `AUS_sew_oppose_gbr` | GBRがASTと同盟 or GBR_sew_commonwealth_duty | antagonize GBR+100 |
 
 ---
 
-### Namespace: `sew_aus`（エミュー帝国反応）
+## AIストラテジープラン設計（実装済み）
 
-| ID | タイトル | 発火条件 | 概要 |
-|----|---------|---------|------|
-| `sew_aus.1` | 侵略宣言の正当化 | AUS, AST宣戦後 | エミュー帝国議会が「防衛戦争」と宣言 |
-| `sew_aus.2` | 英国干渉への警告 | AUS, GBR支援後 | GBRへの外交的抗議 |
-| `sew_aus.3` | エミュー統一戦線 | AUS, 特定条件 | 野生エミューを徴兵する緊急令 |
+### HRH_sew_resistance_plan（常時有効）
+- **概要**: 本土抵抗勢力として武装強化→外交→西海岸奪還の一本道
+- **フォーカス順**: focus_1→2→A2→3→A3→4→4A→AB3→A4→5→6→7→8
+- **research**: infantry_weapons=50, support_tech=30, land_doctrine=25, naval=-99
+- **focus_factors**: focus_5×2.0 / focus_6×2.0 / focus_8×3.0
+- **weight**: 基本1.0、HRH_recapture_success後×1.5
 
----
+### AST_sew_intervention_plan（積極介入、Bokka_Alliance参加後に有効化）
+- **概要**: HRH全面支援→参戦→西部奪還の積極路線
+- **フォーカス順**: respond→send_advisors→supply→joint_training→artillery→naval→combined_ops→contact_gbr→gbr_aid→mobilize→declare→reclaim_west→recognition→gbr_thanks
+- **research**: naval_equipment=45, infantry_weapons=35, support_tech=25
+- **focus_factors**: send_advisors×3.0 / mobilize×2.5 / declare_war×3.0 / reclaim_west×2.0
+- **weight**: 基本1.0、Bokka_Alliance参加で×2.0、参戦後×1.5
 
-## 国家精神（Ideas）設計
-
-### `second_emu_war_ideas.txt`
-
-```
-# AST用
-AST_sew_mobilization         # 総動員令 - 兵力+、安定度-
-AST_sew_anti_emu_doctrine    # 対エミュー教義 - 対歩兵戦闘ボーナス
-AST_sew_british_support      # 英国の支援 - 研究速度+、政治力+
-AST_sew_independence_spirit  # 独立不羈の精神 - 降伏限界+（英国拒否ルート）
-
-# HRH用
-HRH_sew_liberation_cause     # 解放の大義 - 戦意+、士気+
-HRH_sew_guerrilla_mastery    # ゲリラ戦の極意 - 防御戦闘+
-
-# GBR関連
-GBR_emu_intervention_cost    # 介入コスト - 消費財-、政治力消費+（軍事介入時ペナルティ）
-GBR_colonial_scrutiny        # 植民地問題の監視 - 自治領独立傾向+（傍観ルートのペナルティ）
-
-# AUS（エミュー帝国）用
-AUS_sew_war_footing          # 第二次大戦体制 - 徴兵+、生産効率+
-AUS_sew_surrounded           # 四面楚歌 - 防御+、攻撃-（包囲された場合）
-```
+### AST_sew_defense_plan（国防優先、Bokka_Alliance未参加時）
+- **概要**: タスマニア防衛優先・物資支援のみ・直接参戦回避
+- **フォーカス順**: respond→supply→artillery→naval→contact_gbr→gbr_independent
+- **research**: naval_equipment=40, infantry_weapons=40
+- **focus_factors**: supply×2.0, naval_support×2.0, gbr_independent×2.5, mobilize=0.0, declare_war=0.0
+- **weight**: 基本0.5、AST_sew_independence_spirit取得で×2.0、AUS戦争中は×0.0（プラン無効化）
 
 ---
 
-## ディシジョン設計
-
-### `second_emu_war_decisions.txt`
-
-```
-# AST用ディシジョン
-AST_sew_call_hrh_alliance    # ハットリバーに合流を呼びかける（HRH参戦促進）
-AST_sew_scorched_earth       # 焦土作戦（エミュー追撃妨害、プロビンス破壊と引き換え）
-AST_sew_demand_gbr_help      # GBRへの正式援助要請
-AST_sew_war_bonds            # 戦時国債発行（工場建設資金）
-
-# HRH用ディシジョン
-HRH_sew_request_recognition  # GBRへ国家承認を要請
-HRH_sew_partisan_ops         # エミュー帝国領内でのパルチザン活動
-HRH_sew_covert_supply        # ASTから非公式に武器供給を受ける
-
-# GBR用ディシジョン
-GBR_sew_deploy_advisors      # 軍事顧問団の派遣（AST強化）
-GBR_sew_naval_blockade       # 海上封鎖（AUSの輸入妨害）
-GBR_sew_broker_ceasefire     # 停戦仲介（AUSとASTの交渉）
-```
-
----
-
-## ゲームフロー（シナリオ分岐）
+## ゲームフロー（実装済みシナリオ）
 
 ```
 1936年スタート
     │
-    ├─ HRH：沿岸奪還フォーカス（既存）完了
-    │       ↓
-    │    牧歌同盟の結成(既存) → [新] 第二次エミュー戦争フォーカス解禁
+    ├─ HRH：既存フォーカスツリー進行
+    │   focus_1→2→3→4/4A→A2→A3→AB3→A4→5(TECH_2解放)→6(recapture_started)
+    │                                                         ↓
+    │              ディシジョン: HRH_recapture_neighborhood (30日, 70%成功)
+    │                                                         ↓
+    │              HRH_recapture_success フラグ → focus_7→8
+    │                                                         ↓
+    │              HRH_recapture_states.2 (AST視点) → Bokka_Alliance 結成
+    │                                                         ↓
+    │              sew_support.1 が HRH に届く ★新コンテンツ開始★
     │
-    ├─ AST：第二次エミュー戦争フォーカスツリー開始
-    │   │
-    │   ├─ 英国援助要請ルート
-    │   │   ├─ GBR受諾 → 英国顧問団+コモンウェルス戦争
-    │   │   └─ GBR拒否 → 独立路線（安定度ボーナス、GBR関係悪化）
-    │   │
-    │   └─ 総力戦宣言ルート
-    │       └─ HRH合流 → 西部解放作戦 → AUS首都包囲
+    ├─ AST：sew_support.2 受信後の4択
+    │   ├─ a) 装備支援 → HRH_sew_ast_equipped idea + 装備2000 + sew_support.4
+    │   ├─ b) 顧問派遣 → HRH_sew_ast_advisors idea + tech_bonus
+    │   ├─ c) 参戦確認 → AST_sew_ready_to_intervene フラグ → sew_support.5
+    │   └─ d) 拒否 → HRH_sew_alone_spirit idea → sew_support.3
     │
-    └─ AUS：防衛・反撃フォーカスが発動
-        │
-        ├─ GBR干渉なし → AUS拡張継続、AST苦境
-        └─ GBR介入あり → AUS多正面作戦で苦境
+    ├─ AST フォーカスツリー（ast_second_emu_war_focus）
+    │   ├─ 積極介入プラン（AI: AST_sew_intervention_plan）
+    │   │   respond→advisors/supply→joint/artillery/naval→mobilize→declare_war
+    │   │       └→ 戦後: reclaim_west / recognition / gbr_thanks
+    │   └─ 消極支援プラン（AI: AST_sew_defense_plan）
+    │       respond→supply→naval→contact_gbr→gbr_independent
+    │
+    └─ AUS：sew_aus.1受信 → war_footing または defensive_posture を選択
 
 【エンドステート分岐】
-  A: AST勝利  → エミュー帝国解体、HRH独立承認、オーストラリア再統一
-  B: 停戦     → 暫定国境線で膠着、GBR調停成立
-  C: AUS勝利  → AST敗北、HRH消滅、エミュー帝国がコモンウェルスを脅かす
+  A: AST勝利  → reclaim_west（州879-885がASTコア）+ HRH自治承認
+  B: 交渉停戦 → gbr_thank_you（英国仲介ルート）
+  C: AUS勝利  → HRH_sew_alone_spirit 持続、AST撤退
 ```
 
 ---
 
-## ローカライゼーション計画
+## ローカライゼーション（実装済み）
 
-### `second_emu_war_l_japanese.yml`
+**ファイル**: `bakasekai/localisation/japanese/bakasekai/second_emu_war_l_japanese.yml`
 
-- フォーカス名・説明テキスト（日本語）
-- イベントタイトル・本文・選択肢（日本語）
-- 国家精神名・説明（日本語）
-- ディシジョン名・説明（日本語）
-
-※英語ローカライゼーション (`second_emu_war_l_english.yml`) は後続作業
+収録テキスト:
+- フォーカス名・説明文（13フォーカス分）
+- イベントタイトル・本文・選択肢テキスト（10イベント分）
+- 国家精神名・フレーバーテキスト（16精神分）
+- 関連ツールチップ（`_tt` キー）
 
 ---
 
-## 優先実装順序
+## 実装状況チェックリスト
+
+| 項目 | ステータス | コミット |
+|------|-----------|---------|
+| ブランチ作成 (`feature/second-emu-war`) | ✅ 完了 | — |
+| コンテンツプランドキュメント初版 | ✅ 完了 | `1de65044` |
+| HRH「本土抵抗勢力」方針確認 | ✅ 完了 | — |
+| AST支援イベント (`second_emu_war_ast_support_events.txt`) | ✅ 完了 | `f66a895b` |
+| ASTフォーカスツリー (`AST_second_emu_war.txt`) | ✅ 完了 | `f66a895b` |
+| 国家精神 (`second_emu_war_ideas.txt`) | ✅ 完了 | `f66a895b` |
+| 日本語ローカライゼーション | ✅ 完了 | `f66a895b` |
+| AI師団編制テンプレート (`sew_templates.txt`) | ✅ 完了 | `a311d160` |
+| AIストラテジー (`sew_strategies.txt`) | ✅ 完了 | `a311d160` |
+| AIストラテジープラン (`sew_strategy_plans.txt`) | ✅ 完了 | `a311d160` |
+| コンテンツプランドキュメント修正版 | ✅ 完了 | — |
+
+---
+
+## 将来の拡張候補（未実装）
 
 | 優先度 | 作業 | 備考 |
 |--------|------|------|
-| 🔴 高 | `second_emu_war_events.txt` | コアとなるイベント10本 |
-| 🔴 高 | `second_emu_war_ideas.txt` | 国家精神6本 |
-| 🔴 高 | `second_emu_war_l_japanese.yml` | 全テキストのローカライゼーション |
-| 🟡 中 | `AST_second_emu_war.txt` | ASTフォーカスツリー拡張 |
-| 🟡 中 | `HRH_second_emu_war.txt` | HRHフォーカスツリー拡張 |
-| 🟡 中 | `second_emu_war_decisions.txt` | ディシジョン8本 |
-| 🟢 低 | `sew_gbr_events.txt` | GBRイベント5本 |
-| 🟢 低 | `sew_aus_events.txt` | AUSイベント3本 |
-| 🟢 低 | `GBR_emu_intervention.txt` | GBRフォーカス3本 |
+| 🟡 中 | `HRH_second_emu_war.txt` | HRHフォーカスツリー拡張（focus_8以降の継続） |
+| 🟡 中 | `GBR_emu_intervention.txt` | GBR介入フォーカス3本 |
+| 🟡 中 | `second_emu_war_decisions.txt` | AST/HRH/GBR追加ディシジョン群 |
+| 🟢 低 | sew_aus追加イベント | AUSの詳細な反応イベント追加 |
+| 🟢 低 | 英語ローカライゼーション | `second_emu_war_l_english.yml` |
+| 🟢 低 | GFXアイコン | カスタムフォーカスアイコン追加 |
 
 ---
 
 ## 注意事項・実装ガイドライン
 
 ### 既存コンテンツとの接続ポイント
-- **HRHフォーカス**: `HRH_focus_8`（牧歌同盟の結成）の完了後に `HRH_sew_rearm` を解禁
-- **ASTフォーカス**: `AST_commonwealth` コスメティックタグ使用中なので国旗・UI維持に注意
-- **AUSフォーカス**: `AUS_great_emu_war_victory` の後続ルートとして位置づける
-- **イベント namespace 競合**: 既存 `emu`, `emu_empire`, `HRH`, `HRH_recapture_states` と重複しないこと
+- **接続点**: `HRH_recapture_states.2`（AST側イベント）内で `sew_support.1` を HRH に送信
+- **既存ディシジョン**: `HRH_recapture_neighborhood` (decisions/HRH.txt) は無改変で動作
+- **AIテンプレート競合**: `ai_templates_minor_cost_focus.txt` の `available_for` にHRHが既含 → 新テンプレートは `upgrade_prio×3` 以上で上書き
+
+### 技術的制約
+- HRH_TECH_2（militia+irregular解放）は `HRH_focus_5` 完了で自動取得 → AIテンプレートで安全に使用可
+- ASTの海軍上陸が主軸（タスマニア→西オーストラリア）→ marines roleとnaval_invasion_focusが重要
+- Bokka_Alliance（`create_faction = Bokka_Alliance`）は既存イベントで作成済み
 
 ### コーディング規約
-- イベントID: `second_emu_war.N`、`sew_gbr.N`、`sew_aus.N`
-- フォーカスID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`
-- アイデアID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`、`AUS_sew_*`
-- ディシジョンID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`
+- イベントID: `sew_support.N`, `sew_aus.N`, `sew_gbr.N`
+- フォーカスID: `AST_sew_*`
+- アイデアID: `AST_sew_*`, `HRH_sew_*`, `AUS_sew_*`, `GBR_sew_*`
+- テンプレートID: `HRH_sew_*` / `AST_sew_*` / `AUS_sew_*`
+- ストラテジーID: `HRH_sew_*` / `AST_sew_*` / `AUS_sew_*`
+- プランID: `HRH_sew_*` / `AST_sew_*`
 
 ### バカ世界地図の精神
 - エミューはあくまで「勝利した知性を持つ鳥」として描写
 - シリアスになりすぎず、笑えるフレーバーテキストを心がける
-- ハットリバーの「農家が独立を宣言した」設定を活かした小国感
+- ハットリバーの「農場主が独立を宣言した」設定を活かした小国感
 - イギリスは「なぜかコモンウェルスで鳥と戦う羽目になった」感を演出
+- エミュー帝国の「防衛戦争」宣言は徹底したギャグ路線で

--- a/CONTENT_PLAN_second_emu_war.md
+++ b/CONTENT_PLAN_second_emu_war.md
@@ -1,0 +1,284 @@
+# 第二次エミュー戦争 コンテンツプラン
+## ブランチ: `feature/second-emu-war`
+## 作成日: 2026-05-22
+
+---
+
+## 概要・世界観
+
+「第二次エミュー戦争」は、**エミュー帝国(AUS)** の勢力拡大に対し、
+**オーストラリア連邦(AST)** と **ハットリバー公国(HRH)** が共同戦線を張り、
+さらに本国イギリス **(GBR)** の介入・思惑が絡む多角的な紛争シナリオ。
+
+### 史実ベース（バカ世界地図解釈）
+| 要素 | 史実 | 本MODでの解釈 |
+|------|------|--------------|
+| 大エミュー戦争(1932) | オーストラリア軍がエミュー駆除作戦に失敗 | エミューが勝利し「エミュー帝国」を樹立 |
+| ハットリバー公国 | 1970年にオーストラリアから独立宣言 | エミューに領土を奪われた亡命政権 |
+| イギリスとオーストラリア | コモンウェルス関係 | エミュー問題への干渉・コモンウェルス維持 vs 放棄の駆け引き |
+
+---
+
+## 関係国タグ一覧
+
+| タグ | 国名 | 役割 |
+|------|------|------|
+| `AUS` | エミュー帝国 | 今回の主な敵対勢力 |
+| `AST` | オーストラリア連邦 | 主人公側・反エミュー連合の中核 |
+| `HRH` | ハットリバー公国 | 亡命政権・AST側盟友 |
+| `GBR` | イギリス | 第三勢力・コモンウェルス問題で介入 |
+
+---
+
+## 新規ファイル構成
+
+```
+bakasekai/
+├── events/
+│   ├── second_emu_war_events.txt       # 第二次エミュー戦争イベント群(AST/HRH視点)
+│   ├── second_emu_war_gbr_events.txt   # イギリス介入イベント群
+│   └── second_emu_war_aus_events.txt   # エミュー帝国側反応イベント群
+├── common/
+│   ├── national_focus/
+│   │   ├── AST_second_emu_war.txt      # AST用フォーカスツリー拡張
+│   │   ├── HRH_second_emu_war.txt      # HRH用フォーカスツリー拡張
+│   │   └── GBR_emu_intervention.txt    # GBR介入フォーカス(小規模)
+│   ├── ideas/
+│   │   └── second_emu_war_ideas.txt    # 新国家精神・国家方針
+│   └── decisions/
+│       └── second_emu_war_decisions.txt # 関連ディシジョン
+└── localisation/
+    └── japanese/bakasekai/
+        └── second_emu_war_l_japanese.yml
+```
+
+---
+
+## フォーカスツリー設計
+
+### AST（オーストラリア連邦）拡張ツリー
+**フォーカスツリーID**: `ast_second_emu_war_focus`（既存`australia.txt`への追加も検討）
+
+```
+[AST_sew_root] 第二次エミュー戦争への備え
+    │
+    ├── [AST_sew_recall_emu_war]  大エミュー戦争の教訓
+    │       └── [AST_sew_new_doctrine]  対エミュー戦闘教義
+    │               └── [AST_sew_anti_emu_unit]  エミュー駆除部隊創設
+    │
+    ├── [AST_sew_hrh_alliance]  ハットリバーと手を組む
+    │       └── [AST_sew_combined_arms]  合同作戦計画
+    │               └── [AST_sew_liberation_of_west]  西部解放作戦
+    │
+    ├── [AST_sew_gbr_request]  英国への援助要請
+    │       ├── [AST_sew_gbr_accepted]  英国軍の上陸支援(GBR友好時)
+    │       └── [AST_sew_gbr_rejected]  独力で戦う(GBR拒否時)
+    │
+    └── [AST_sew_total_war]  総力戦宣言
+            └── [AST_sew_final_push]  最終攻勢
+                    └── [AST_sew_victory]  エミュー帝国の解体
+```
+
+---
+
+### HRH（ハットリバー公国）拡張ツリー
+**既存ツリーへの追加フォーカス**
+
+```
+[HRH_focus_8]（既存：牧歌同盟の結成）の後続
+    │
+    ├── [HRH_sew_rearm]         再武装計画
+    │       └── [HRH_sew_militia_elite]  精鋭民兵団
+    │
+    ├── [HRH_sew_legitimacy]    正統性の宣言
+    │       └── [HRH_sew_gbr_recognition] GBRへの承認要請
+    │               ├── [HRH_sew_commonwealth_member] コモンウェルス加盟
+    │               └── [HRH_sew_full_independence]  完全独立路線
+    │
+    └── [HRH_sew_intel_network]  諜報網構築
+            └── [HRH_sew_sabotage]  エミュー帝国内部工作
+```
+
+---
+
+### GBR（イギリス）介入フォーカス（小規模）
+
+```
+[GBR_emu_crisis] エミュー危機への対応
+    ├── [GBR_emu_intervene]     軍事介入 → ASTへの軍事支援
+    ├── [GBR_emu_mediate]       調停外交 → 停戦交渉
+    └── [GBR_emu_abandon]       傍観      → コモンウェルス弱体化
+```
+
+---
+
+## イベントシナリオ設計
+
+### Namespace: `second_emu_war`（AST/HRH視点）
+
+| ID | タイトル | 発火条件 | 概要 |
+|----|---------|---------|------|
+| `second_emu_war.1` | 第二次エミュー戦争の予兆 | AST, fire_only_once, date>1937.1.1 | エミュー帝国の膨張を察知したAST首脳部の緊急会議 |
+| `second_emu_war.2` | 国境侵犯事件 | AST, AUSと隣接後N月 | AUSの小部隊がAST領土内に侵入 |
+| `second_emu_war.3` | ハットリバーからの救援要請 | AST, HRH存在時 | HRHがASTに共同作戦を要請 |
+| `second_emu_war.4` | 英国大使の訪問 | AST, GBR健在時 | GBRがコモンウェルス維持を条件に援助を申し出る |
+| `second_emu_war.5` | 砂漠の罠 | AST, has_war=AUS | エミュー軍が砂漠地帯に誘引作戦を展開 |
+| `second_emu_war.6` | ハットリバー民兵の奮闘 | HRH, has_war=AUS | HRH民兵が英雄的な防衛戦を展開 |
+| `second_emu_war.7` | 開戦宣言 | AST, フォーカス完了時 | 正式な対エミュー帝国宣戦布告 |
+| `second_emu_war.8` | 西部戦線の突破 | AST, 特定州占領後 | 西オーストラリア州の一部解放成功 |
+| `second_emu_war.9` | エミュー皇帝の演説 | AUS視点でも通知 | エミュー帝国が「聖戦」を宣言 |
+| `second_emu_war.10` | 停戦か継続か | AST, AUSの首都占領後 | 戦後処理の分岐点 |
+
+---
+
+### Namespace: `sew_gbr`（イギリス介入イベント）
+
+| ID | タイトル | 発火条件 | 概要 |
+|----|---------|---------|------|
+| `sew_gbr.1` | エミュー問題とコモンウェルス | GBR, date>1937.3.1 | 議会でオーストラリア問題が議題に |
+| `sew_gbr.2` | オーストラリアからの支援要請 | GBR, AST発火後 | ASTのSOSを受け取ったGBR |
+| `sew_gbr.3` | 軍事顧問団の派遣 | GBR, 支援選択後 | GBR軍事顧問がAST軍を指導 |
+| `sew_gbr.4` | コモンウェルス会議の招集 | GBR, 調停選択後 | カナダ・NZも巻き込んだ外交交渉 |
+| `sew_gbr.5` | 英国の撤退 | GBR, 傍観選択後 | コモンウェルス関係の見直し通告 |
+
+---
+
+### Namespace: `sew_aus`（エミュー帝国反応）
+
+| ID | タイトル | 発火条件 | 概要 |
+|----|---------|---------|------|
+| `sew_aus.1` | 侵略宣言の正当化 | AUS, AST宣戦後 | エミュー帝国議会が「防衛戦争」と宣言 |
+| `sew_aus.2` | 英国干渉への警告 | AUS, GBR支援後 | GBRへの外交的抗議 |
+| `sew_aus.3` | エミュー統一戦線 | AUS, 特定条件 | 野生エミューを徴兵する緊急令 |
+
+---
+
+## 国家精神（Ideas）設計
+
+### `second_emu_war_ideas.txt`
+
+```
+# AST用
+AST_sew_mobilization         # 総動員令 - 兵力+、安定度-
+AST_sew_anti_emu_doctrine    # 対エミュー教義 - 対歩兵戦闘ボーナス
+AST_sew_british_support      # 英国の支援 - 研究速度+、政治力+
+AST_sew_independence_spirit  # 独立不羈の精神 - 降伏限界+（英国拒否ルート）
+
+# HRH用
+HRH_sew_liberation_cause     # 解放の大義 - 戦意+、士気+
+HRH_sew_guerrilla_mastery    # ゲリラ戦の極意 - 防御戦闘+
+
+# GBR関連
+GBR_emu_intervention_cost    # 介入コスト - 消費財-、政治力消費+（軍事介入時ペナルティ）
+GBR_colonial_scrutiny        # 植民地問題の監視 - 自治領独立傾向+（傍観ルートのペナルティ）
+
+# AUS（エミュー帝国）用
+AUS_sew_war_footing          # 第二次大戦体制 - 徴兵+、生産効率+
+AUS_sew_surrounded           # 四面楚歌 - 防御+、攻撃-（包囲された場合）
+```
+
+---
+
+## ディシジョン設計
+
+### `second_emu_war_decisions.txt`
+
+```
+# AST用ディシジョン
+AST_sew_call_hrh_alliance    # ハットリバーに合流を呼びかける（HRH参戦促進）
+AST_sew_scorched_earth       # 焦土作戦（エミュー追撃妨害、プロビンス破壊と引き換え）
+AST_sew_demand_gbr_help      # GBRへの正式援助要請
+AST_sew_war_bonds            # 戦時国債発行（工場建設資金）
+
+# HRH用ディシジョン
+HRH_sew_request_recognition  # GBRへ国家承認を要請
+HRH_sew_partisan_ops         # エミュー帝国領内でのパルチザン活動
+HRH_sew_covert_supply        # ASTから非公式に武器供給を受ける
+
+# GBR用ディシジョン
+GBR_sew_deploy_advisors      # 軍事顧問団の派遣（AST強化）
+GBR_sew_naval_blockade       # 海上封鎖（AUSの輸入妨害）
+GBR_sew_broker_ceasefire     # 停戦仲介（AUSとASTの交渉）
+```
+
+---
+
+## ゲームフロー（シナリオ分岐）
+
+```
+1936年スタート
+    │
+    ├─ HRH：沿岸奪還フォーカス（既存）完了
+    │       ↓
+    │    牧歌同盟の結成(既存) → [新] 第二次エミュー戦争フォーカス解禁
+    │
+    ├─ AST：第二次エミュー戦争フォーカスツリー開始
+    │   │
+    │   ├─ 英国援助要請ルート
+    │   │   ├─ GBR受諾 → 英国顧問団+コモンウェルス戦争
+    │   │   └─ GBR拒否 → 独立路線（安定度ボーナス、GBR関係悪化）
+    │   │
+    │   └─ 総力戦宣言ルート
+    │       └─ HRH合流 → 西部解放作戦 → AUS首都包囲
+    │
+    └─ AUS：防衛・反撃フォーカスが発動
+        │
+        ├─ GBR干渉なし → AUS拡張継続、AST苦境
+        └─ GBR介入あり → AUS多正面作戦で苦境
+
+【エンドステート分岐】
+  A: AST勝利  → エミュー帝国解体、HRH独立承認、オーストラリア再統一
+  B: 停戦     → 暫定国境線で膠着、GBR調停成立
+  C: AUS勝利  → AST敗北、HRH消滅、エミュー帝国がコモンウェルスを脅かす
+```
+
+---
+
+## ローカライゼーション計画
+
+### `second_emu_war_l_japanese.yml`
+
+- フォーカス名・説明テキスト（日本語）
+- イベントタイトル・本文・選択肢（日本語）
+- 国家精神名・説明（日本語）
+- ディシジョン名・説明（日本語）
+
+※英語ローカライゼーション (`second_emu_war_l_english.yml`) は後続作業
+
+---
+
+## 優先実装順序
+
+| 優先度 | 作業 | 備考 |
+|--------|------|------|
+| 🔴 高 | `second_emu_war_events.txt` | コアとなるイベント10本 |
+| 🔴 高 | `second_emu_war_ideas.txt` | 国家精神6本 |
+| 🔴 高 | `second_emu_war_l_japanese.yml` | 全テキストのローカライゼーション |
+| 🟡 中 | `AST_second_emu_war.txt` | ASTフォーカスツリー拡張 |
+| 🟡 中 | `HRH_second_emu_war.txt` | HRHフォーカスツリー拡張 |
+| 🟡 中 | `second_emu_war_decisions.txt` | ディシジョン8本 |
+| 🟢 低 | `sew_gbr_events.txt` | GBRイベント5本 |
+| 🟢 低 | `sew_aus_events.txt` | AUSイベント3本 |
+| 🟢 低 | `GBR_emu_intervention.txt` | GBRフォーカス3本 |
+
+---
+
+## 注意事項・実装ガイドライン
+
+### 既存コンテンツとの接続ポイント
+- **HRHフォーカス**: `HRH_focus_8`（牧歌同盟の結成）の完了後に `HRH_sew_rearm` を解禁
+- **ASTフォーカス**: `AST_commonwealth` コスメティックタグ使用中なので国旗・UI維持に注意
+- **AUSフォーカス**: `AUS_great_emu_war_victory` の後続ルートとして位置づける
+- **イベント namespace 競合**: 既存 `emu`, `emu_empire`, `HRH`, `HRH_recapture_states` と重複しないこと
+
+### コーディング規約
+- イベントID: `second_emu_war.N`、`sew_gbr.N`、`sew_aus.N`
+- フォーカスID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`
+- アイデアID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`、`AUS_sew_*`
+- ディシジョンID: `AST_sew_*`、`HRH_sew_*`、`GBR_sew_*`
+
+### バカ世界地図の精神
+- エミューはあくまで「勝利した知性を持つ鳥」として描写
+- シリアスになりすぎず、笑えるフレーバーテキストを心がける
+- ハットリバーの「農家が独立を宣言した」設定を活かした小国感
+- イギリスは「なぜかコモンウェルスで鳥と戦う羽目になった」感を演出

--- a/bakasekai/common/ai_strategy/sew_strategies.txt
+++ b/bakasekai/common/ai_strategy/sew_strategies.txt
@@ -1,0 +1,620 @@
+# 第二次エミュー戦争 AIストラテジー
+# 対象国: HRH / AST / AUS
+# 状況に応じた役割比率・研究・外交・生産AIを定義
+
+######################################
+# HRH（ハットリバー公国）
+######################################
+
+# 平時: 不正規戦主体の小国編制
+HRH_sew_peacetime_force = {
+	enable = {
+		original_tag = HRH
+		has_war = no
+	}
+	abort_when_not_enabled = yes
+
+	# 歩兵を最大化・戦車ゼロ
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 90
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = armor
+		value = -100
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = cavalry
+		value = -100
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = marines
+		value = 0
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = paratroopers
+		value = 0
+	}
+	# 小国なので守備・制圧も最小
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 5
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = suppression
+		value = 2
+	}
+}
+
+# 戦時: 対AUS戦時の不正規+正規ミックス
+HRH_sew_wartime_force = {
+	enable = {
+		original_tag = HRH
+		has_war_with = AUS
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 85
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 10
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = suppression
+		value = 3
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = armor
+		value = -100
+	}
+
+	# 歩兵装備生産を最優先
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = 60
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = artillery
+		value = 20
+	}
+}
+
+# HRH研究優先度: 歩兵・支援・ドクトリン
+HRH_sew_research_priority = {
+	enable = {
+		original_tag = HRH
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = research_tech
+		id = infantry_weapons
+		value = 40
+	}
+	ai_strategy = {
+		type = research_tech
+		id = support_tech
+		value = 30
+	}
+	ai_strategy = {
+		type = research_tech
+		id = land_doctrine
+		value = 20
+	}
+	# 海軍・空軍・戦車研究は不要
+	ai_strategy = {
+		type = research_tech
+		id = armor
+		value = -50
+	}
+	ai_strategy = {
+		type = research_tech
+		id = naval_equipment
+		value = -80
+	}
+	ai_strategy = {
+		type = research_tech
+		id = air_equipment
+		value = -30
+	}
+}
+
+# HRH外交: ASTとの関係強化、AUSへの対抗
+HRH_sew_diplomacy_support_ast = {
+	enable = {
+		original_tag = HRH
+		AST = { exists = yes }
+	}
+	abort = {
+		NOT = { AST = { exists = yes } }
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = "AST"
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = "AST"
+		value = 100
+	}
+}
+
+HRH_sew_diplomacy_oppose_aus = {
+	enable = {
+		original_tag = HRH
+		AUS = { exists = yes }
+	}
+	abort = {
+		NOT = { AUS = { exists = yes } }
+	}
+
+	ai_strategy = {
+		type = antagonize
+		id = "AUS"
+		value = 100
+	}
+}
+
+# HRH生産: 軍工場建設優先（小国ゆえ手動工場確保）
+HRH_sew_production_priority = {
+	enable = {
+		original_tag = HRH
+	}
+	abort_when_not_enabled = yes
+
+	# 民間工場より軍工場
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 100
+	}
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 10
+	}
+	ai_strategy = {
+		type = building_target
+		id = infrastructure
+		value = 20
+	}
+}
+
+# HRH: AST装備支援を受けたら歩兵装備生産を緩める
+HRH_sew_supplied_by_ast = {
+	enable = {
+		original_tag = HRH
+		has_idea = HRH_sew_ast_equipped
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = -20  # ASTから貰えるので自力生産を減らす
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = artillery
+		value = 10
+	}
+}
+
+######################################
+# AST（オーストラリア連邦）
+######################################
+
+# AST基本兵力比率（タスマニア守備期）
+AST_sew_base_force = {
+	enable = {
+		original_tag = AST
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 75
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = marines
+		value = 5   # 海からの上陸作戦を想定
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = armor
+		value = -50  # 初期は戦車なし
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 10
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = paratroopers
+		value = 0
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = cavalry
+		value = -100
+	}
+}
+
+# AST参戦後: 対エミュー上陸作戦体制
+AST_sew_wartime_force = {
+	enable = {
+		original_tag = AST
+		has_war_with = AUS
+	}
+	abort_when_not_enabled = yes
+
+	# 海兵比率を上げて上陸作戦を強化
+	ai_strategy = {
+		type = role_ratio
+		id = marines
+		value = 15
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 70
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 8
+	}
+
+	# 海軍資産を積極活用
+	ai_strategy = {
+		type = unit_ratio
+		id = screen_ship
+		value = 10
+	}
+	ai_strategy = {
+		type = unit_ratio
+		id = convoy
+		value = 15
+	}
+
+	# 歩兵・砲兵装備生産強化
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = 50
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = artillery
+		value = 30
+	}
+}
+
+# AST研究優先度
+AST_sew_research_priority = {
+	enable = {
+		original_tag = AST
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = research_tech
+		id = infantry_weapons
+		value = 30
+	}
+	ai_strategy = {
+		type = research_tech
+		id = support_tech
+		value = 25
+	}
+	ai_strategy = {
+		type = research_tech
+		id = naval_equipment
+		value = 35  # 海軍国として海軍重視
+	}
+	ai_strategy = {
+		type = research_tech
+		id = land_doctrine
+		value = 15
+	}
+}
+
+# AST外交: HRH支援・GBR協調・AUS対抗
+AST_sew_diplomacy_hrh = {
+	enable = {
+		original_tag = AST
+		HRH = {
+			exists = yes
+			has_country_flag = HRH_recapture_success
+		}
+	}
+	abort = {
+		NOT = { HRH = { exists = yes } }
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = "HRH"
+		value = 200
+	}
+	ai_strategy = {
+		type = support
+		id = "HRH"
+		value = 100
+	}
+}
+
+AST_sew_diplomacy_gbr = {
+	enable = {
+		original_tag = AST
+		GBR = {
+			exists = yes
+			NOT = { has_war_with = AST }
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = befriend
+		id = "GBR"
+		value = 50
+	}
+}
+
+AST_sew_diplomacy_oppose_aus = {
+	enable = {
+		original_tag = AST
+		AUS = { exists = yes }
+	}
+	abort = {
+		NOT = { AUS = { exists = yes } }
+	}
+
+	ai_strategy = {
+		type = antagonize
+		id = "AUS"
+		value = 150
+	}
+}
+
+# AST: HRHへの支援AIウィル
+AST_sew_supply_hrh_ai = {
+	enable = {
+		original_tag = AST
+		HRH = {
+			exists = yes
+			has_war_with = AUS
+		}
+		has_war = no
+	}
+	abort = {
+		OR = {
+			NOT = { HRH = { exists = yes } }
+			has_war = yes
+		}
+	}
+
+	# HRHへの物資補給を積極的に行う
+	ai_strategy = {
+		type = support
+		id = "HRH"
+		value = 150
+	}
+}
+
+# AST: 参戦後の上陸拠点優先エリア
+AST_sew_area_priority = {
+	enable = {
+		original_tag = AST
+		has_war_with = AUS
+	}
+	abort_when_not_enabled = yes
+
+	# オセアニア・太平洋が主戦場
+	ai_strategy = {
+		type = area_priority
+		id = oceania
+		value = 200
+	}
+	ai_strategy = {
+		type = area_priority
+		id = pacific
+		value = 100
+	}
+	ai_strategy = {
+		type = area_priority
+		id = asia
+		value = -50
+	}
+	ai_strategy = {
+		type = area_priority
+		id = europe
+		value = -100
+	}
+	ai_strategy = {
+		type = area_priority
+		id = africa
+		value = -100
+	}
+
+	# 海軍侵攻を積極的に使う
+	ai_strategy = {
+		type = naval_invasion_focus
+		value = 200
+	}
+}
+
+######################################
+# AUS（エミュー帝国）
+######################################
+
+# AUS基本兵力: 大国・広域維持
+AUS_sew_base_force = {
+	enable = {
+		original_tag = AUS
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 80
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 8
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = suppression
+		value = 5
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = cavalry
+		value = 3
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = armor
+		value = -80  # エミューに戦車は似合わない
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = marines
+		value = 0
+	}
+}
+
+# AUS戦時体制: HRH+ASTとの多正面戦争
+AUS_sew_wartime_force = {
+	enable = {
+		original_tag = AUS
+		OR = {
+			has_war_with = HRH
+			has_war_with = AST
+		}
+		has_idea = AUS_sew_war_footing
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = role_ratio
+		id = infantry
+		value = 85
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = garrison
+		value = 10
+	}
+	ai_strategy = {
+		type = role_ratio
+		id = suppression
+		value = 5
+	}
+
+	# 歩兵装備を大量生産
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = 60
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = artillery
+		value = 15
+	}
+}
+
+# AUS防衛態勢: 西海岸を守る
+AUS_sew_defend_west = {
+	enable = {
+		original_tag = AUS
+		has_war_with = HRH
+		# HRHに884州を奪われた場合
+		NOT = { controls_state = 884 }
+	}
+	abort = {
+		controls_state = 884
+	}
+
+	ai_strategy = {
+		type = area_priority
+		id = oceania
+		value = 300
+	}
+	# 884州を奪還する意志
+	ai_strategy = {
+		type = conquer
+		id = "HRH"
+		value = 100
+	}
+}
+
+# AUS研究優先度
+AUS_sew_research_priority = {
+	enable = {
+		original_tag = AUS
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = research_tech
+		id = infantry_weapons
+		value = 40
+	}
+	ai_strategy = {
+		type = research_tech
+		id = land_doctrine
+		value = 25
+	}
+	ai_strategy = {
+		type = research_tech
+		id = support_tech
+		value = 20
+	}
+}
+
+# AUS vs GBR介入: GBRへの対抗
+AUS_sew_oppose_gbr = {
+	enable = {
+		original_tag = AUS
+		GBR = {
+			exists = yes
+			OR = {
+				is_in_faction_with = AST
+				has_idea = GBR_sew_commonwealth_duty
+			}
+		}
+	}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = antagonize
+		id = "GBR"
+		value = 100
+	}
+}

--- a/bakasekai/common/ai_strategy_plans/sew_strategy_plans.txt
+++ b/bakasekai/common/ai_strategy_plans/sew_strategy_plans.txt
@@ -1,0 +1,278 @@
+# 第二次エミュー戦争 AIストラテジープラン
+# 対象国: HRH（ハットリバー公国）/ AST（オーストラリア連邦）
+# WES.txt の構造を参考に作成
+#
+# HRH: 本土抵抗勢力としての生存戦略 → AST支援獲得 → Bokka_Alliance戦争遂行
+# AST: HRH支援 → 参戦判断 → 西オーストラリア奪還の2プラン
+
+######################################
+# HRH（ハットリバー公国）
+# プラン: 抵抗勢力の生存・反攻路線
+######################################
+
+# HRH唯一のプラン: 常時有効（フラグ不要）
+# 抵抗勢力として武装強化→外交→西海岸奪還の一本道
+HRH_sew_resistance_plan = {
+	name = "ハットリバー解放戦争"
+	desc = "本土に孤立した抵抗勢力として、民兵・不正規戦力を整備しながらASTとの連携でエミュー帝国に対抗する。"
+
+	allowed = {
+		original_tag = HRH
+	}
+	enable = {
+		original_tag = HRH
+	}
+	abort = {
+		NOT = { original_tag = HRH }
+	}
+
+	# ─── フォーカス優先順位 ───
+	# 序盤: 武装・兵站整備を最優先
+	# 中盤: 同盟勢力確保・西海岸奪還作戦
+	# 後期: AST連携での戦後体制構築
+	ai_national_focuses = {
+		HRH_focus_1      # 政治力確保・基礎強化（即座に着手）
+		HRH_focus_2      # 民兵組織化（HRH_TECH_1 = 歩兵装備解放）
+		HRH_focus_A2     # 外交網構築開始（並行して進める）
+		HRH_focus_3      # 軍工場増設・装備備蓄
+		HRH_focus_A3     # 先住民同盟（人的資源拡充）
+		HRH_focus_4      # 女性兵士（国家精神で戦力底上げ）
+		HRH_focus_4A     # 対ゲリラ専門家育成（HRH_TECH_3 = ゲリラ戦術）
+		HRH_focus_AB3    # アボリジニ義勇兵師団編成
+		HRH_focus_A4     # 民兵師団「Hutt River Militias」編成
+		HRH_focus_5      # 不正規師団編成（HRH_TECH_2 = militia+irregular解放）
+		HRH_focus_6      # 西海岸奪還作戦開始（HRH_recapture_startedフラグ）
+		HRH_focus_7      # 解放地の安定化
+		HRH_focus_8      # AST支援要請・Bokka_Alliance設立
+	}
+
+	# ─── 研究優先度 ───
+	# 不正規戦特化の小国なので歩兵・支援を最大化
+	# 海軍・戦車は完全除外
+	research = {
+		infantry_weapons  = 50.0   # 主力装備、最優先
+		support_tech      = 30.0   # 工兵・砲兵支援で師団強化
+		land_doctrine     = 25.0   # ゲリラ戦術運用に必要
+		infantry_tech     = 15.0   # irregular/militia強化
+		artillery         = 10.0   # 砲撃支援（支援砲兵）
+		naval_equipment   = -99.0  # 不要
+		armor             = -99.0  # 不要
+		air_equipment     = -30.0  # 最低限の防空のみ
+	}
+
+	# ─── アイデア優先度（将来の大臣選択への誘導） ───
+	ideas = {
+		# 現在のHRH固有アイデアなし（将来の拡張用）
+	}
+
+	traits = {
+		# 将来の将軍特性優先度用（現在は空）
+	}
+
+	# ─── プランの重み ───
+	# 唯一のプランなので weight=1.0 固定
+	weight = {
+		factor = 1.0
+		modifier = {
+			# 884州確保後（西海岸奪還成功）はさらに重みを増す
+			factor = 1.5
+			has_country_flag = HRH_recapture_success
+		}
+	}
+
+	focus_factors = {
+		# HRH_focus_5（不正規師団編成）を最優先タスクの一つに
+		HRH_focus_5 = 2.0
+		# 西海岸奪還ディシジョンに向けた準備フォーカスを加速
+		HRH_focus_6 = 2.0
+		# AST合流フォーカス（外交的最重要）
+		HRH_focus_8 = 3.0
+	}
+}
+
+######################################
+# AST（オーストラリア連邦）
+# プラン1: HRH積極支援路線（介入主義）
+# プラン2: HRH消極支援路線（国防優先）
+######################################
+
+# ─── AST プラン1: 積極介入・西部奪還 ───
+# HRH_recapture_success後にASTがBokka_Allianceに参加した場合に有効化
+AST_sew_intervention_plan = {
+	name = "西部解放作戦"
+	desc = "HRHへの全面支援を宣言し、軍事顧問・物資・参戦を通じてエミュー帝国との決戦に臨む。勝利後は西オーストラリアを奪還する。"
+
+	allowed = {
+		original_tag = AST
+	}
+	enable = {
+		original_tag = AST
+		# Bokka_Alliance参加済み or 積極支援フラグが立っている
+		OR = {
+			is_in_faction_with = HRH
+			has_country_flag = AST_sew_respond_to_hrh_done
+		}
+		HRH = {
+			exists = yes
+			has_country_flag = HRH_recapture_success
+		}
+	}
+	abort = {
+		OR = {
+			NOT = { HRH = { exists = yes } }
+			# AUSとの戦争が終わったら（勝利or講和）中断
+			AND = {
+				NOT = { has_war_with = AUS }
+				has_completed_focus = AST_sew_declare_war
+			}
+		}
+	}
+
+	# ─── フォーカス優先順位 ───
+	# 支援→顧問→動員→参戦→戦後の順で一本道
+	# 左(物資)ブランチと中央(顧問)ブランチを並行進行
+	ai_national_focuses = {
+		AST_sew_respond_to_hrh          # ルート: HRHへ連絡・支援意思表示
+		AST_sew_send_advisors           # 中央: 軍事顧問派遣（HRH強化の核心）
+		AST_sew_supply_hrh              # 左: 物資・装備の直接提供
+		AST_sew_joint_training          # 中央: 合同訓練（HRHのドクトリン研究加速）
+		AST_sew_artillery_support       # 左: 砲兵装備追加支援
+		AST_sew_naval_support           # 左: 海上補給路確保（ASTの海軍力活用）
+		AST_sew_combined_ops_plan       # 中央: 合同作戦計画策定
+		AST_sew_contact_gbr             # 右: 英国への外交アプローチ
+		AST_sew_gbr_military_aid        # 右: 英国軍事援助受領
+		AST_sew_mobilize                # 合流: 全体動員令・参戦最終準備
+		AST_sew_declare_war             # 参戦: 対AUS宣戦布告
+		AST_sew_reclaim_west            # 戦後: 西部再統合（コア追加）
+		AST_sew_post_war_hrh_recognition # 戦後: HRH自治承認
+		AST_sew_gbr_thank_you           # 戦後: 英国への感謝外交
+	}
+
+	# ─── 研究優先度 ───
+	# 海軍上陸作戦が主軸 → 海軍+歩兵+支援をバランスよく
+	research = {
+		naval_equipment   = 45.0   # 海軍国としての最優先事項（上陸作戦に必須）
+		infantry_weapons  = 35.0   # 地上部隊の主力
+		support_tech      = 25.0   # 海兵支援・工兵
+		land_doctrine     = 20.0   # 合同作戦ドクトリン
+		infantry_tech     = 15.0   # 師団強化
+		artillery         = 12.0   # 砲兵支援
+		armor             = -50.0  # 当面不要（タスマニア地形に不向き）
+		air_equipment     = 10.0   # 最低限の制空
+	}
+
+	ideas = {
+		# 将来の大臣選択優先度（現在は空欄）
+	}
+
+	traits = {
+		# 将軍特性優先度（現在は空欄）
+	}
+
+	# ─── プランの重み ───
+	weight = {
+		factor = 1.0
+		modifier = {
+			# Bokka_Alliance参加済みで優先度UP
+			factor = 2.0
+			is_in_faction_with = HRH
+		}
+		modifier = {
+			# 参戦フォーカス完了後はさらにUP（戦後処理を急ぐ）
+			factor = 1.5
+			has_completed_focus = AST_sew_declare_war
+		}
+	}
+
+	focus_factors = {
+		# 軍事顧問を最重要ブランチとして加速
+		AST_sew_send_advisors    = 3.0
+		# 参戦は最大優先度
+		AST_sew_mobilize         = 2.5
+		AST_sew_declare_war      = 3.0
+		# 西部奪還は最終ゴール
+		AST_sew_reclaim_west     = 2.0
+	}
+}
+
+# ─── AST プラン2: 国防優先・消極支援 ───
+# ASTがBokka_Allianceに参加していない / 独立路線を選んだ場合
+# 直接参戦はせず、物資のみ支援するスタンスを維持
+AST_sew_defense_plan = {
+	name = "タスマニア防衛路線"
+	desc = "タスマニアの防衛を最優先とし、HRHへの支援は物資提供に留める。エミュー帝国との直接対決は避けつつ、独立国家としての立場を固める。"
+
+	allowed = {
+		original_tag = AST
+	}
+	enable = {
+		original_tag = AST
+		# Bokka_Alliance未参加 かつ HRHがまだ戦争中
+		NOT = { is_in_faction_with = HRH }
+		HRH = {
+			exists = yes
+			has_country_flag = HRH_recapture_success
+		}
+	}
+	abort = {
+		# Bokka_Alliance参加したら積極介入プランに切り替え
+		is_in_faction_with = HRH
+	}
+
+	# ─── フォーカス優先順位 ───
+	# 物資支援ブランチのみ進み、参戦は回避
+	# 英国独立路線（AST_sew_gbr_independent）を選択
+	ai_national_focuses = {
+		AST_sew_respond_to_hrh      # 最低限の外交的応答
+		AST_sew_supply_hrh          # 物資支援のみ（最小介入）
+		AST_sew_artillery_support   # 砲兵装備支援
+		AST_sew_naval_support       # 海上補給路（タスマニア防衛も兼ねる）
+		AST_sew_contact_gbr         # 英国との関係維持
+		AST_sew_gbr_independent     # 独立路線選択（コモンウェルス依存脱却）
+	}
+
+	# ─── 研究優先度 ───
+	# 防衛中心 → 歩兵・海軍を固める
+	research = {
+		infantry_weapons  = 40.0   # 地上防衛の要
+		naval_equipment   = 40.0   # タスマニア海峡防衛
+		support_tech      = 20.0   # 防衛支援
+		land_doctrine     = 15.0   # 陣地防衛ドクトリン
+		infantry_tech     = 12.0   # 師団強化
+		armor             = -80.0  # 不要
+		air_equipment     = 15.0   # 制空権維持
+	}
+
+	ideas = {
+	}
+
+	traits = {
+	}
+
+	# ─── プランの重み ───
+	# デフォルトでは低め — 積極介入プランが有効な場合は自動的にそちらが優先
+	weight = {
+		factor = 0.5
+		modifier = {
+			# 独立精神国家精神を持つ場合は重みUP
+			factor = 2.0
+			has_idea = AST_sew_independence_spirit
+		}
+		modifier = {
+			# AUSと戦争になったら（どちらかが攻め込まれた）このプランは無効化
+			factor = 0.0
+			has_war_with = AUS
+		}
+	}
+
+	focus_factors = {
+		# 物資支援ブランチを最優先
+		AST_sew_supply_hrh       = 2.0
+		AST_sew_naval_support    = 2.0
+		# 英国独立路線を選ぶよう誘導
+		AST_sew_gbr_independent  = 2.5
+		# 参戦フォーカスには手を出さない
+		AST_sew_mobilize         = 0.0
+		AST_sew_declare_war      = 0.0
+	}
+}

--- a/bakasekai/common/ai_templates/sew_templates.txt
+++ b/bakasekai/common/ai_templates/sew_templates.txt
@@ -1,0 +1,343 @@
+# 第二次エミュー戦争 師団編制AIテンプレート
+# 対象国: HRH（ハットリバー公国）/ AST（オーストラリア連邦）/ AUS（エミュー帝国）
+
+######################################
+# HRH（ハットリバー公国）
+# 特性: 小国・民兵主体・不正規戦特化
+######################################
+
+# ─── 歩兵ロール（主力：不正規兵+民兵） ───
+HRH_sew_infantry = {
+	available_for = { HRH }
+	role = infantry
+	upgrade_prio = {
+		factor = 3
+	}
+
+	# 序盤: 軽装不正規師団（州884確保直後）
+	HRH_irregular_core = {
+		upgrade_prio = {
+			factor = 3
+		}
+		target_template = {
+			support = {
+				recon     = 1
+				engineer  = 1
+			}
+			regiments = {
+				irregular_infantry = 4
+				militia             = 3
+			}
+		}
+		replace_at_match = 0.8
+		replace_with     = HRH_irregular_reinforced
+		target_min_match = 0.5
+	}
+
+	# 中盤: AST装備支給後に強化（sew_support.2 装備支援選択後）
+	HRH_irregular_reinforced = {
+		upgrade_prio = {
+			factor = 2
+			modifier = {
+				factor = 3
+				# AST装備支援を受けた場合に優先度UP
+				has_idea = HRH_sew_ast_equipped
+			}
+		}
+		target_template = {
+			support = {
+				recon     = 1
+				engineer  = 1
+				artillery = 1
+			}
+			regiments = {
+				irregular_infantry = 5
+				militia             = 3
+				infantry            = 1
+			}
+		}
+		replace_at_match = 0.9
+		replace_with     = HRH_regular_combined
+		target_min_match = 0.5
+	}
+
+	# 後期: AST顧問団指導後の正規化師団
+	HRH_regular_combined = {
+		upgrade_prio = {
+			factor = 1
+			modifier = {
+				factor = 4
+				has_idea = HRH_sew_ast_advisors
+			}
+		}
+		target_template = {
+			support = {
+				recon     = 1
+				engineer  = 1
+				artillery = 1
+				anti_tank = 1
+			}
+			regiments = {
+				infantry            = 6
+				irregular_infantry  = 3
+			}
+		}
+	}
+}
+
+# ─── 守備ロール（拠点防衛） ───
+HRH_sew_garrison = {
+	available_for = { HRH }
+	role = garrison
+	upgrade_prio = {
+		factor = 2
+	}
+
+	HRH_garrison_militia = {
+		reinforce_prio = 0
+		custom_icon = 7
+		upgrade_prio = {
+			factor = 1
+		}
+		target_template = {
+			regiments = {
+				militia = 4
+			}
+		}
+	}
+}
+
+# ─── 制圧ロール（占領地維持） ───
+HRH_sew_suppression = {
+	available_for = { HRH }
+	role = suppression
+	upgrade_prio = {
+		factor = 1
+	}
+
+	HRH_suppression_light = {
+		reinforce_prio = 0
+		custom_icon = 13
+		upgrade_prio = {
+			factor = 1
+		}
+		target_template = {
+			regiments = {
+				irregular_infantry = 3
+				militia             = 2
+			}
+		}
+	}
+}
+
+######################################
+# AST（オーストラリア連邦）
+# 特性: タスマニア亡命政府・海軍重視・
+#       HRH支援後は本土上陸戦力を構築
+######################################
+
+# ─── 歩兵ロール ───
+AST_sew_infantry = {
+	available_for = { AST }
+	role = infantry
+	upgrade_prio = {
+		factor = 3
+	}
+
+	# 序盤: 標準歩兵（タスマニア守備）
+	AST_standard_infantry = {
+		upgrade_prio = {
+			factor = 2
+		}
+		target_template = {
+			support = {
+				engineer  = 1
+				artillery = 1
+			}
+			regiments = {
+				infantry = 9
+			}
+		}
+		replace_at_match = 0.9
+		replace_with     = AST_assault_infantry
+		target_min_match = 0.5
+	}
+
+	# 中盤: 対エミュー強襲歩兵（参戦フォーカス後）
+	AST_assault_infantry = {
+		upgrade_prio = {
+			factor = 2
+			modifier = {
+				factor = 3
+				has_idea = AST_sew_war_mobilization
+			}
+		}
+		target_template = {
+			support = {
+				engineer  = 1
+				artillery = 1
+				anti_tank = 1
+				recon     = 1
+			}
+			regiments = {
+				infantry            = 9
+				anti_tank_brigade   = 1
+			}
+		}
+	}
+}
+
+# ─── 海兵ロール（本土上陸作戦） ───
+AST_sew_marines = {
+	available_for = { AST }
+	role = marines
+	upgrade_prio = {
+		factor = 2
+		modifier = {
+			factor = 4
+			# 参戦フォーカス取得後に優先度UP
+			has_completed_focus = AST_sew_declare_war
+		}
+	}
+
+	AST_marine_landing = {
+		upgrade_prio = {
+			factor = 2
+		}
+		target_template = {
+			support = {
+				engineer = 1
+				recon    = 1
+			}
+			regiments = {
+				marine   = 4
+				infantry = 2
+			}
+		}
+	}
+}
+
+# ─── 守備ロール ───
+AST_sew_garrison = {
+	available_for = { AST }
+	role = garrison
+	upgrade_prio = {
+		factor = 1
+	}
+
+	AST_garrison_standard = {
+		reinforce_prio = 0
+		custom_icon = 7
+		upgrade_prio = {
+			factor = 1
+		}
+		target_template = {
+			regiments = {
+				infantry = 4
+			}
+		}
+	}
+}
+
+######################################
+# AUS（エミュー帝国）
+# 特性: 大国・歩兵主体・機動力重視
+#       民兵で広大な本土を維持
+######################################
+
+# ─── 歩兵ロール ───
+AUS_sew_infantry = {
+	available_for = { AUS }
+	role = infantry
+	upgrade_prio = {
+		factor = 3
+	}
+
+	# 序盤〜中盤: エミュー標準師団
+	AUS_emu_standard = {
+		upgrade_prio = {
+			factor = 2
+		}
+		target_template = {
+			support = {
+				recon    = 1
+				engineer = 1
+			}
+			regiments = {
+				infantry = 9
+				cavalry  = 1   # 哨戒・機動用
+			}
+		}
+		replace_at_match = 0.9
+		replace_with     = AUS_emu_wartime
+		target_min_match = 0.5
+	}
+
+	# 戦時体制（AUS_sew_war_footing取得後）
+	AUS_emu_wartime = {
+		upgrade_prio = {
+			factor = 2
+			modifier = {
+				factor = 5
+				has_idea = AUS_sew_war_footing
+			}
+		}
+		target_template = {
+			support = {
+				recon     = 1
+				engineer  = 1
+				artillery = 1
+				anti_tank = 1
+			}
+			regiments = {
+				infantry = 9
+				militia  = 2
+			}
+		}
+	}
+}
+
+# ─── 守備ロール（本土各州の広域維持） ───
+AUS_sew_garrison = {
+	available_for = { AUS }
+	role = garrison
+	upgrade_prio = {
+		factor = 2
+	}
+
+	AUS_garrison_wide = {
+		reinforce_prio = 0
+		custom_icon = 7
+		upgrade_prio = {
+			factor = 1
+		}
+		target_template = {
+			regiments = {
+				infantry = 4
+				militia  = 2
+			}
+		}
+	}
+}
+
+# ─── 制圧ロール（占領地・解放区） ───
+AUS_sew_suppression = {
+	available_for = { AUS }
+	role = suppression
+	upgrade_prio = {
+		factor = 1
+	}
+
+	AUS_suppression_cavalry = {
+		reinforce_prio = 0
+		custom_icon = 13
+		upgrade_prio = {
+			factor = 1
+		}
+		target_template = {
+			regiments = {
+				cavalry = 4
+			}
+		}
+	}
+}

--- a/bakasekai/common/ideas/second_emu_war_ideas.txt
+++ b/bakasekai/common/ideas/second_emu_war_ideas.txt
@@ -1,0 +1,241 @@
+# 第二次エミュー戦争 国家精神・アイデア
+# 関係国: AST / HRH / AUS / GBR
+
+ideas = {
+	country = {
+
+		# ─────────────────────────────────────────
+		# AST（オーストラリア連邦）用
+		# ─────────────────────────────────────────
+
+		# 動員令 — 参戦時の総動員
+		AST_sew_war_mobilization = {
+			picture = generic_manpower_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				conscription = 0.05
+				war_support_factor = 0.10
+				stability_factor = -0.05
+				industrial_capacity_factory = 0.05
+			}
+		}
+
+		# 参戦準備中 — まだ宣戦していない段階の軍備増強
+		AST_sew_war_preparation = {
+			picture = generic_prepare_civil_war
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				conscription = 0.02
+				training_time_factor = -0.10
+				army_org_factor = 0.05
+			}
+		}
+
+		# 英国連絡将校 — GBRがリエゾン派遣
+		AST_sew_british_liaison = {
+			picture = generic_military_intelligence
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_morale_factor = 0.05
+				planning_speed = 0.10
+				research_speed_factor = 0.03
+			}
+		}
+
+		# 英国の積極支援 — GBRフォーカスで支援決定後
+		AST_sew_british_support_active = {
+			picture = generic_goods_red_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				production_speed_arms_factory_factor = 0.05
+				equipment_conversion_speed = 0.10
+				army_attack_factor = 0.03
+			}
+		}
+
+		# 独立不羈の精神 — GBRを頼らず独自路線
+		AST_sew_independence_spirit = {
+			picture = generic_war_support
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				stability_factor = 0.05
+				surrender_limit = 0.05
+				political_power_factor = 0.10
+				war_support_factor = 0.05
+			}
+		}
+
+		# 西海岸補給路 — 海路でHRHに物資輸送
+		AST_sew_western_coast_supply_route = {
+			picture = generic_navy_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				naval_speed_factor = 0.05
+				convoy_escort_efficiency = 0.10
+				HRH = {
+					army_org_regain = 0.05
+				}
+			}
+		}
+
+		# 西部奪還完了 — 戦後処理ボーナス
+		AST_sew_west_reclaimed = {
+			picture = generic_political_rally
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				stability_factor = 0.10
+				political_power_factor = 0.15
+				war_support_factor = 0.05
+			}
+		}
+
+		# ─────────────────────────────────────────
+		# HRH（ハットリバー公国）用
+		# ─────────────────────────────────────────
+
+		# AST装備支給 — ASTから武器を受け取った
+		HRH_sew_ast_equipped = {
+			picture = generic_goods_red_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_attack_factor = 0.05
+				supply_consumption_factor = -0.05
+				equipment_capture_factor = 0.10
+			}
+		}
+
+		# AST軍事顧問団 — ASTの顧問団が指導
+		HRH_sew_ast_advisors = {
+			picture = generic_military_intelligence
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_morale_factor = 0.08
+				planning_speed = 0.15
+				army_org_factor = 0.05
+				land_doctrine_cost_factor = -0.10
+			}
+		}
+
+		# AST全面支援 — ASTが参戦を表明
+		HRH_sew_ast_full_support = {
+			picture = generic_war_support
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_morale_factor = 0.15
+				war_support_factor = 0.20
+				surrender_limit = 0.10
+				army_attack_factor = 0.08
+			}
+		}
+
+		# 合同作戦ボーナス — AST・HRH協同で戦術改善
+		HRH_sew_combined_ops_bonus = {
+			picture = generic_army_doctrines
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				coordination_bonus = 0.1
+				army_attack_factor = 0.05
+				army_defence_factor = 0.05
+			}
+		}
+
+		# 孤立した抵抗 — ASTの支援なしで独立継続
+		HRH_sew_alone_spirit = {
+			picture = generic_morale_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_core_defence_factor = 0.10
+				resistance_target = 0.10
+				war_support_factor = 0.05
+				surrender_limit = 0.05
+			}
+		}
+
+		# ASTからの国家承認 — 戦後自治州として承認
+		HRH_sew_ast_recognition = {
+			picture = generic_political_rally
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				stability_factor = 0.15
+				political_power_factor = 0.20
+				war_support_factor = -0.05
+			}
+		}
+
+		# ─────────────────────────────────────────
+		# AUS（エミュー帝国）用
+		# ─────────────────────────────────────────
+
+		# 第二次大戦体制 — AST参戦に対する総動員
+		AUS_sew_war_footing = {
+			picture = generic_manpower_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				conscription = 0.05
+				army_morale_factor = 0.10
+				war_support_factor = 0.10
+				production_speed_arms_factory_factor = 0.10
+			}
+		}
+
+		# 防御態勢 — 攻勢より防衛に切り替え
+		AUS_sew_defensive_posture = {
+			picture = generic_fortify_city
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				army_core_defence_factor = 0.15
+				dig_in_speed_factor = 0.20
+				army_attack_factor = -0.05
+			}
+		}
+
+		# ─────────────────────────────────────────
+		# GBR（イギリス）用オピニオン・モディファイア参照
+		# ─────────────────────────────────────────
+		# ※ opinion_modifiers は別途 opinion_modifiers.txt に記載推奨
+		# 　 ここでは国家精神のみ定義
+
+		# コモンウェルス積極関与 — ASTへの介入決定後
+		GBR_sew_commonwealth_duty = {
+			picture = generic_goods_red_bonus
+			allowed = { always = no }
+			allowed_civil_war = { always = yes }
+			removal_cost = -1
+			modifier = {
+				political_power_factor = -0.10
+				stability_factor = -0.02
+				war_support_factor = 0.05
+			}
+		}
+	}
+}

--- a/bakasekai/common/national_focus/AST_second_emu_war.txt
+++ b/bakasekai/common/national_focus/AST_second_emu_war.txt
@@ -1,0 +1,452 @@
+# AST（オーストラリア連邦）フォーカスツリー拡張
+# 第二次エミュー戦争 — HRH支援・対AUS参戦
+# HRH_recapture_success フラグが立った後に解禁される
+
+focus_tree = {
+	id = ast_second_emu_war_focus
+
+	country = {
+		factor = 0
+		modifier = {
+			add = 10
+			tag = AST
+		}
+	}
+
+	default = no
+
+	# ─────────────────────────────────────────
+	# ルート: 牧歌同盟への応答
+	# 前提: HRHから牧歌同盟への参加要請を受けた後
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_respond_to_hrh
+		icon = GFX_goal_generic_improve_relations
+		cost = 3
+		x = 7
+		y = 0
+
+		available = {
+			# 牧歌同盟(Bokka_Alliance)が存在 or HRHが参加要請済み
+			OR = {
+				is_in_faction_with = HRH
+				has_country_flag = AST_sew_hrh_contacted
+			}
+			HRH = {
+				exists = yes
+				has_country_flag = HRH_recapture_success
+			}
+		}
+
+		completion_reward = {
+			add_political_power = 50
+			HRH = {
+				country_event = { id = sew_support.1 days = 1 }
+			}
+			set_country_flag = AST_sew_respond_to_hrh_done
+		}
+	}
+
+	# ─────────────────────────────────────────
+	# 左ブランチ: 物資・装備支援ルート
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_supply_hrh
+		icon = GFX_goal_ammunitions
+		cost = 7
+		x = 4
+		y = 1
+		prerequisite = { focus = AST_sew_respond_to_hrh }
+
+		available = {
+			HRH = {
+				exists = yes
+			}
+		}
+
+		completion_reward = {
+			HRH = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment_1
+					amount = 3000
+					producer = AST
+				}
+				add_equipment_to_stockpile = {
+					type = support_equipment
+					amount = 300
+					producer = AST
+				}
+			}
+			add_political_power = -30
+			add_opinion_modifier = {
+				target = HRH
+				modifier = AST_supported_hrh_logistics
+			}
+		}
+	}
+
+	focus = {
+		id = AST_sew_artillery_support
+		icon = GFX_goal_generic_army_artillery2
+		cost = 7
+		x = 3
+		y = 2
+		prerequisite = { focus = AST_sew_supply_hrh }
+
+		available = {
+			HRH = {
+				exists = yes
+			}
+		}
+
+		completion_reward = {
+			HRH = {
+				add_equipment_to_stockpile = {
+					type = artillery_equipment_1
+					amount = 400
+					producer = AST
+				}
+			}
+			add_tech_bonus = {
+				name = AST_sew_art_supply_bonus
+				bonus = 0.1
+				uses = 1
+				category = artillery
+			}
+		}
+	}
+
+	focus = {
+		id = AST_sew_naval_support
+		icon = GFX_goal_generic_navy_doctrines_tactics
+		cost = 7
+		x = 5
+		y = 2
+		prerequisite = { focus = AST_sew_supply_hrh }
+
+		available = {
+			HRH = {
+				exists = yes
+			}
+		}
+
+		# 西海岸沿いの海上補給路を確保、HRHへの海路輸送
+		completion_reward = {
+			add_ideas = AST_sew_western_coast_supply_route
+			HRH = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment_1
+					amount = 1000
+					producer = AST
+				}
+			}
+			add_political_power = -20
+		}
+	}
+
+	# ─────────────────────────────────────────
+	# 中央ブランチ: 軍事顧問・合同作戦ルート
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_send_advisors
+		icon = GFX_goal_generic_military_sphere
+		cost = 7
+		x = 7
+		y = 1
+		prerequisite = { focus = AST_sew_respond_to_hrh }
+
+		available = {
+			HRH = {
+				exists = yes
+			}
+		}
+
+		completion_reward = {
+			HRH = {
+				add_ideas = HRH_sew_ast_advisors
+				army_experience = 15
+			}
+			add_political_power = -40
+			set_country_flag = AST_sew_advisors_sent
+		}
+	}
+
+	focus = {
+		id = AST_sew_joint_training
+		icon = GFX_goal_generic_army_doctrines
+		cost = 7
+		x = 6
+		y = 2
+		prerequisite = { focus = AST_sew_send_advisors }
+
+		completion_reward = {
+			HRH = {
+				add_tech_bonus = {
+					name = HRH_sew_joint_doctrine
+					bonus = 0.4
+					uses = 2
+					category = land_doctrine
+				}
+			}
+			army_experience = 10
+		}
+	}
+
+	focus = {
+		id = AST_sew_combined_ops_plan
+		icon = GFX_goal_generic_attack
+		cost = 7
+		x = 8
+		y = 2
+		prerequisite = { focus = AST_sew_send_advisors }
+
+		available = {
+			HRH = {
+				has_war_with = AUS
+			}
+		}
+
+		# HRHの前線を支援する合同作戦計画を策定
+		completion_reward = {
+			HRH = {
+				add_ideas = HRH_sew_combined_ops_bonus
+			}
+			set_country_flag = AST_sew_combined_ops_ready
+		}
+	}
+
+	# ─────────────────────────────────────────
+	# 右ブランチ: 英国への接触
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_contact_gbr
+		icon = GFX_goal_generic_alliance
+		cost = 7
+		x = 10
+		y = 1
+		prerequisite = { focus = AST_sew_respond_to_hrh }
+
+		available = {
+			GBR = {
+				exists = yes
+				NOT = { has_war_with = AST }
+			}
+		}
+
+		completion_reward = {
+			GBR = {
+				country_event = { id = sew_gbr.1 days = 3 }
+			}
+			add_opinion_modifier = {
+				target = GBR
+				modifier = AST_reached_out_to_gbr
+			}
+			add_political_power = 20
+		}
+	}
+
+	focus = {
+		id = AST_sew_gbr_military_aid
+		icon = GFX_goal_generic_improve_relations
+		cost = 7
+		x = 9
+		y = 2
+		prerequisite = { focus = AST_sew_contact_gbr }
+
+		available = {
+			GBR = {
+				exists = yes
+				has_opinion = {
+					target = AST
+					value > 20
+				}
+			}
+		}
+
+		# GBRから装備支援を受ける
+		completion_reward = {
+			add_equipment_to_stockpile = {
+				type = infantry_equipment_1
+				amount = 2000
+				producer = GBR
+			}
+			add_ideas = AST_sew_british_support_active
+		}
+	}
+
+	focus = {
+		id = AST_sew_gbr_independent
+		icon = GFX_goal_generic_political_pressure
+		cost = 5
+		x = 11
+		y = 2
+		prerequisite = { focus = AST_sew_contact_gbr }
+		mutually_exclusive = { focus = AST_sew_gbr_military_aid }
+
+		# GBRとは独立して動く — コモンウェルス関係を見直す
+		completion_reward = {
+			add_ideas = AST_sew_independence_spirit
+			add_stability = 0.05
+			add_political_power = 50
+		}
+	}
+
+	# ─────────────────────────────────────────
+	# 参戦フォーカス（合流点）
+	# 物資 or 顧問ルートのどちらかを経由後
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_mobilize
+		icon = GFX_goal_generic_national_unity
+		cost = 10
+		x = 7
+		y = 3
+
+		prerequisite = {
+			focus = AST_sew_artillery_support
+			focus = AST_sew_naval_support
+		}
+		prerequisite = {
+			focus = AST_sew_joint_training
+			focus = AST_sew_combined_ops_plan
+		}
+
+		# どちらか片方のブランチが揃えば参戦準備へ
+		available = {
+			HRH = {
+				exists = yes
+				has_war_with = AUS
+			}
+		}
+
+		completion_reward = {
+			add_ideas = AST_sew_war_mobilization
+			set_country_flag = AST_sew_ready_to_intervene
+			country_event = { id = sew_support.5 days = 1 }
+		}
+	}
+
+	focus = {
+		id = AST_sew_declare_war
+		icon = GFX_goal_generic_major_war
+		cost = 5
+		x = 7
+		y = 4
+		prerequisite = { focus = AST_sew_mobilize }
+
+		available = {
+			has_country_flag = AST_sew_ready_to_intervene
+			HRH = {
+				has_war_with = AUS
+			}
+		}
+
+		# 対AUS宣戦布告（HRHに参加）
+		completion_reward = {
+			join_faction_of = HRH
+			declare_war_on = {
+				target = AUS
+				type = annex_everything
+			}
+			add_war_support = 0.15
+			HRH = {
+				country_event = { id = sew_support.7 days = 1 }
+			}
+			AUS = {
+				country_event = { id = sew_aus.1 days = 1 }
+			}
+		}
+	}
+
+	# ─────────────────────────────────────────
+	# 戦後処理ブランチ（AST勝利後）
+	# ─────────────────────────────────────────
+	focus = {
+		id = AST_sew_post_war_hrh_recognition
+		icon = GFX_goal_generic_political_pressure
+		cost = 10
+		x = 5
+		y = 5
+		prerequisite = { focus = AST_sew_declare_war }
+
+		available = {
+			NOT = { has_war_with = AUS }
+			HRH = {
+				exists = yes
+			}
+		}
+
+		# HRHをオーストラリア連邦の自治州として承認
+		completion_reward = {
+			HRH = {
+				add_ideas = HRH_sew_ast_recognition
+				add_political_power = 100
+				add_stability = 0.10
+			}
+			add_political_power = 50
+		}
+	}
+
+	focus = {
+		id = AST_sew_reclaim_west
+		icon = GFX_goal_generic_territory_or_war
+		cost = 10
+		x = 7
+		y = 5
+		prerequisite = { focus = AST_sew_declare_war }
+
+		available = {
+			NOT = { has_war_with = AUS }
+			# 西オーストラリア州群を奪還済み
+			controls_state = 879
+			controls_state = 884
+		}
+
+		# 西部再統合 — コアとしてASTが主張
+		completion_reward = {
+			every_state = {
+				limit = {
+					is_core_of = AUS
+					OR = {
+						state = 879
+						state = 880
+						state = 881
+						state = 882
+						state = 883
+						state = 884
+						state = 885
+					}
+				}
+				add_core_of = AST
+			}
+			add_stability = 0.10
+			add_ideas = AST_sew_west_reclaimed
+		}
+	}
+
+	focus = {
+		id = AST_sew_gbr_thank_you
+		icon = GFX_goal_generic_improve_relations
+		cost = 5
+		x = 9
+		y = 5
+		prerequisite = { focus = AST_sew_declare_war }
+
+		available = {
+			NOT = { has_war_with = AUS }
+			has_idea = AST_sew_british_support_active
+		}
+
+		# イギリスへの感謝外交
+		completion_reward = {
+			GBR = {
+				add_political_power = 30
+				add_opinion_modifier = {
+					target = AST
+					modifier = GBR_ast_post_war_gratitude
+				}
+			}
+			add_political_power = 30
+		}
+	}
+}

--- a/bakasekai/events/second_emu_war_ast_support_events.txt
+++ b/bakasekai/events/second_emu_war_ast_support_events.txt
@@ -1,0 +1,432 @@
+# 第二次エミュー戦争 - AST支援イベント群
+# HRHが西オーストラリア(state:884)を確保した後、ASTへの支援要請フロー
+# 発火の起点: HRH_recapture_success フラグ + HRH_focus_8(牧歌同盟の結成)
+
+add_namespace = sew_support
+
+######################################
+# sew_support.1 : HRHからASTへの緊急支援要請
+# HRH_recapture_states.2 (既存) でAST側ファクションOKした後、
+# ASTに追加の支援を要請するイベントを飛ばす起点
+######################################
+country_event = {
+	id = sew_support.1
+	title = sew_support.1.t
+	desc = sew_support.1.d
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes   # HRH_recapture_states.2 のoption.aから呼ばれる
+
+	# HRH側に届くイベント（確認通知）
+	trigger = {
+		tag = HRH
+		has_country_flag = HRH_recapture_success
+	}
+
+	option = {
+		# ASTに支援の詳細を要請する
+		name = sew_support.1.a
+		ai_chance = { factor = 90 }
+		AST = {
+			country_event = { id = sew_support.2 days = 2 }
+		}
+		set_country_flag = HRH_ast_support_requested
+	}
+	option = {
+		# 今は独力で戦う
+		name = sew_support.1.b
+		ai_chance = { factor = 10 }
+		add_political_power = 20
+		add_ideas = HRH_sew_alone_spirit
+	}
+}
+
+######################################
+# sew_support.2 : AST側に届く支援要請通知
+# ASTプレイヤー/AIが支援内容を選択する
+######################################
+country_event = {
+	id = sew_support.2
+	title = sew_support.2.t
+	desc = sew_support.2.d
+	picture = GFX_report_event_generic_conference
+
+	is_triggered_only = yes   # sew_support.1 から呼ばれる
+
+	trigger = {
+		tag = AST
+	}
+
+	# 選択肢A: 物資・装備を送る（軽支援）
+	option = {
+		name = sew_support.2.a
+		ai_chance = { factor = 50 }
+		HRH = {
+			add_equipment_to_stockpile = {
+				type = infantry_equipment_1
+				amount = 2000
+				producer = AST
+			}
+			add_equipment_to_stockpile = {
+				type = support_equipment
+				amount = 200
+				producer = AST
+			}
+			add_ideas = HRH_sew_ast_equipped
+		}
+		add_political_power = -30
+		set_country_flag = AST_sew_support_given_equipment
+	}
+
+	# 選択肢B: 軍事顧問団を派遣する（中支援）
+	option = {
+		name = sew_support.2.b
+		ai_chance = { factor = 35 }
+		HRH = {
+			add_ideas = HRH_sew_ast_advisors
+			add_tech_bonus = {
+				name = HRH_sew_ast_military_training
+				bonus = 0.3
+				uses = 2
+				category = land_doctrine
+			}
+		}
+		add_political_power = -50
+		set_country_flag = AST_sew_support_given_advisors
+	}
+
+	# 選択肢C: 正規軍を派遣し共同作戦を展開する（重支援・参戦）
+	option = {
+		name = sew_support.2.c
+		ai_chance = { factor = 10 }
+		HRH = {
+			add_ideas = HRH_sew_ast_full_support
+		}
+		set_country_flag = AST_sew_support_full_intervention
+		# ASTのフォーカスツリーでの参戦フォーカスを解禁するフラグ
+		set_country_flag = AST_sew_ready_to_intervene
+		country_event = { id = sew_support.5 days = 7 }  # 参戦準備イベントへ
+	}
+
+	# 選択肢D: 今は動けない（拒否）
+	option = {
+		name = sew_support.2.d
+		ai_chance = { factor = 5 }
+		HRH = {
+			country_event = { id = sew_support.3 days = 1 }  # 拒否通知
+		}
+		add_opinion_modifier = {
+			target = HRH
+			modifier = AST_abandoned_hrh
+		}
+	}
+}
+
+######################################
+# sew_support.3 : ASTに拒否された時のHRH側通知
+######################################
+country_event = {
+	id = sew_support.3
+	title = sew_support.3.t
+	desc = sew_support.3.d
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = HRH
+	}
+
+	option = {
+		name = sew_support.3.a
+		# 独立路線へ — 士気ボーナス＋安定度ペナルティ
+		add_ideas = HRH_sew_alone_spirit
+		add_stability = -0.05
+		add_war_support = 0.05
+	}
+}
+
+######################################
+# sew_support.4 : 物資/顧問支援後の現地報告
+# AST支援から一定期間後にHRH側で発火
+######################################
+country_event = {
+	id = sew_support.4
+	title = sew_support.4.t
+	desc = sew_support.4.d
+	picture = GFX_report_event_generic_factory
+
+	trigger = {
+		tag = HRH
+		OR = {
+			has_country_flag = AST_sew_support_given_equipment
+			has_country_flag = AST_sew_support_given_advisors
+		}
+		has_war = yes
+		date > 1937.3.1
+	}
+	mean_time_to_happen = {
+		months = 3
+	}
+	fire_only_once = yes
+
+	option = {
+		# 装備が前線に届いた！ 攻勢準備
+		name = sew_support.4.a
+		ai_chance = { factor = 100 }
+		add_war_support = 0.05
+		random_owned_controlled_state = {
+			limit = {
+				is_controlled_by = HRH
+			}
+			add_building_construction = {
+				type = infrastructure
+				level = 1
+				instant_build = yes
+			}
+		}
+		# ASTに感謝と続きの要請を伝える
+		AST = {
+			country_event = { id = sew_support.6 days = 3 }
+		}
+	}
+}
+
+######################################
+# sew_support.5 : ASTの参戦準備（重支援ルート）
+# AST側で参戦の最終確認
+######################################
+country_event = {
+	id = sew_support.5
+	title = sew_support.5.t
+	desc = sew_support.5.d
+	picture = GFX_report_event_generic_military_parade
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = AST
+		has_country_flag = AST_sew_ready_to_intervene
+	}
+
+	option = {
+		# 即時参戦 — AUSに宣戦
+		name = sew_support.5.a
+		ai_chance = { factor = 60 }
+		declare_war_on = {
+			target = AUS
+			type = annex_everything
+		}
+		add_ideas = AST_sew_war_mobilization
+		HRH = {
+			country_event = { id = sew_support.7 days = 1 }  # HRH側通知
+		}
+		AUS = {
+			country_event = { id = sew_aus.1 days = 1 }  # AUS側反応
+		}
+	}
+	option = {
+		# もう少し準備してから参戦
+		name = sew_support.5.b
+		ai_chance = { factor = 40 }
+		add_ideas = AST_sew_war_preparation
+		set_country_flag = AST_sew_preparing_intervention
+		# 60日後に再度確認イベント
+		country_event = { id = sew_support.5 days = 60 }
+	}
+}
+
+######################################
+# sew_support.6 : HRHからの感謝と追加支援要請
+# AST側に届く
+######################################
+country_event = {
+	id = sew_support.6
+	title = sew_support.6.t
+	desc = sew_support.6.d
+	picture = GFX_report_event_generic_sign_treaty2
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = AST
+	}
+
+	option = {
+		# さらに追加支援を送る
+		name = sew_support.6.a
+		ai_chance = { factor = 70 }
+		HRH = {
+			add_equipment_to_stockpile = {
+				type = artillery_equipment_1
+				amount = 300
+				producer = AST
+			}
+			add_manpower = 5000
+		}
+		add_political_power = -40
+	}
+	option = {
+		# 今の支援で十分だ
+		name = sew_support.6.b
+		ai_chance = { factor = 30 }
+		add_political_power = 30
+	}
+}
+
+######################################
+# sew_support.7 : ASTが参戦！ HRH側通知
+######################################
+country_event = {
+	id = sew_support.7
+	title = sew_support.7.t
+	desc = sew_support.7.d
+	picture = GFX_report_event_generic_military_parade
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = HRH
+	}
+
+	option = {
+		name = sew_support.7.a
+		ai_chance = { factor = 100 }
+		add_war_support = 0.15
+		add_stability = 0.05
+		add_political_power = 50
+		# ASTとの関係強化
+		add_opinion_modifier = {
+			target = AST
+			modifier = HRH_grateful_to_ast
+		}
+	}
+}
+
+######################################
+# sew_support.8 : イギリス参観武官の到着
+# GBRが状況を注視 — AST支援中に発火
+# （GBRが健在かつAST支援フラグがある場合）
+######################################
+country_event = {
+	id = sew_support.8
+	title = sew_support.8.t
+	desc = sew_support.8.d
+	picture = GFX_report_event_generic_read_write
+
+	trigger = {
+		tag = AST
+		OR = {
+			has_country_flag = AST_sew_support_given_advisors
+			has_country_flag = AST_sew_ready_to_intervene
+		}
+		GBR = {
+			exists = yes
+			NOT = { has_war_with = AST }
+		}
+		date > 1937.6.1
+	}
+	fire_only_once = yes
+	mean_time_to_happen = {
+		months = 2
+	}
+
+	option = {
+		# 英国の支援を受け入れる
+		name = sew_support.8.a
+		ai_chance = { factor = 60 }
+		add_ideas = AST_sew_british_liaison
+		GBR = {
+			country_event = { id = sew_gbr.1 days = 3 }
+		}
+		add_opinion_modifier = {
+			target = GBR
+			modifier = AST_welcomed_british_liaison
+		}
+	}
+	option = {
+		# コモンウェルスの問題、我々で解決する
+		name = sew_support.8.b
+		ai_chance = { factor = 40 }
+		add_ideas = AST_sew_independence_spirit
+		add_stability = 0.05
+		GBR = {
+			add_opinion_modifier = {
+				target = AST
+				modifier = GBR_ast_independent_policy
+			}
+		}
+	}
+}
+
+######################################
+# sew_aus.1 : AUSがAST参戦に反応
+######################################
+country_event = {
+	id = sew_aus.1
+	title = sew_aus.1.t
+	desc = sew_aus.1.d
+	picture = GFX_report_event_generic_military_parade
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = AUS
+	}
+
+	option = {
+		# 「我らが聖域を侵すとは！全エミュー戦士よ集え！」
+		name = sew_aus.1.a
+		ai_chance = { factor = 80 }
+		add_war_support = 0.10
+		add_ideas = AUS_sew_war_footing
+	}
+	option = {
+		# 「タスマニアを揺さぶれ…戦略的撤退だ」
+		name = sew_aus.1.b
+		ai_chance = { factor = 20 }
+		add_ideas = AUS_sew_defensive_posture
+		add_stability = 0.05
+	}
+}
+
+######################################
+# sew_gbr.1 : イギリスの連絡将校がオーストラリア情勢を報告
+######################################
+country_event = {
+	id = sew_gbr.1
+	title = sew_gbr.1.t
+	desc = sew_gbr.1.d
+	picture = GFX_report_event_generic_conference
+
+	is_triggered_only = yes
+
+	trigger = {
+		tag = GBR
+	}
+
+	option = {
+		# コモンウェルスの義務として支援を続ける
+		name = sew_gbr.1.a
+		ai_chance = { factor = 50 }
+		AST = {
+			add_ideas = AST_sew_british_support_active
+			add_tech_bonus = {
+				name = GBR_ast_military_aid
+				bonus = 0.2
+				uses = 1
+				category = infantry_weapons
+			}
+		}
+		add_political_power = -50
+	}
+	option = {
+		# 現地の問題は現地で解決させる
+		name = sew_gbr.1.b
+		ai_chance = { factor = 50 }
+		add_opinion_modifier = {
+			target = AST
+			modifier = GBR_hands_off_policy
+		}
+	}
+}

--- a/bakasekai/localisation/japanese/bakasekai/second_emu_war_l_japanese.yml
+++ b/bakasekai/localisation/japanese/bakasekai/second_emu_war_l_japanese.yml
@@ -1,0 +1,158 @@
+﻿l_japanese:
+
+ ###########
+ # ASTフォーカスツリー
+ ###########
+ AST_sew_respond_to_hrh:0 "牧歌同盟への応答"
+ AST_sew_respond_to_hrh_desc:0 "ハットリバーは西海岸の一部を確保し、反エミュー戦線を辛うじて維持している。小さな農家の公国が奮闘しているというのに、我々が黙って見ているわけにはいかない。"
+
+ AST_sew_supply_hrh:0 "ハットリバーへの物資支援"
+ AST_sew_supply_hrh_desc:0 "武器・弾薬・補給物資をハットリバーに送り込む。エミューの大群に囲まれた彼らに、まず戦える装備を届けることが先決だ。"
+
+ AST_sew_artillery_support:0 "砲兵装備の提供"
+ AST_sew_artillery_support_desc:0 "エミューの突撃に対抗できる野砲を送る。羽毛の壁を吹き飛ばす鉄のメッセージだ。"
+
+ AST_sew_naval_support:0 "西海岸補給路の確立"
+ AST_sew_naval_support_desc:0 "海路を使ってハットリバーへの物資輸送路を確保する。エミューは泳げない――海は我々の味方だ。"
+
+ AST_sew_send_advisors:0 "軍事顧問団の派遣"
+ AST_sew_send_advisors_desc:0 "経験豊富な将校をハットリバーに送り込み、不正規戦の指導にあたらせる。農家の民兵を精鋭部隊に鍛え上げよう。"
+
+ AST_sew_joint_training:0 "合同訓練プログラム"
+ AST_sew_joint_training_desc:0 "オーストラリア軍とハットリバー軍が共同で訓練を実施する。いずれ来る本格的な反攻に備えて、連携を深めておく必要がある。"
+
+ AST_sew_combined_ops_plan:0 "合同作戦計画の策定"
+ AST_sew_combined_ops_plan_desc:0 "エミュー帝国の弱点を突く合同作戦を立案する。タスマニアから上陸した部隊と西海岸のハットリバーが挟撃できれば、形勢逆転も夢ではない。"
+
+ AST_sew_contact_gbr:0 "英国への打診"
+ AST_sew_contact_gbr_desc:0 "コモンウェルスの盟主たるイギリスに状況を説明し、支援を打診する。ロンドンは何と言うだろうか？エミューをどう思っているのだろうか？"
+
+ AST_sew_gbr_military_aid:0 "英国からの軍事援助"
+ AST_sew_gbr_military_aid_desc:0 "イギリスがコモンウェルスの義務として軍事援助を約束してくれた。英国製の装備がオーストラリアの大地に届く日は近い。"
+
+ AST_sew_gbr_independent:0 "自力解決路線"
+ AST_sew_gbr_independent_desc:0 "イギリスの顔色を窺わず、自らの力でこの問題を解決する。コモンウェルスとの関係は後で考えればいい。今は戦うことだ。"
+
+ AST_sew_mobilize:0 "総動員令"
+ AST_sew_mobilize_desc:0 "エミュー帝国との全面対決に備え、国家総動員を宣言する。工場も農場も学校も、全てが戦争のために動き始める。"
+
+ AST_sew_declare_war:0 "対エミュー帝国宣戦布告"
+ AST_sew_declare_war_desc:0 "ついにその時が来た。オーストラリア連邦は、エミュー帝国に対して正式な宣戦布告を行う。ハットリバーと共に、あのクソ鳥どもを大陸から叩き出してやる。"
+
+ AST_sew_post_war_hrh_recognition:0 "ハットリバーの自治承認"
+ AST_sew_post_war_hrh_recognition_desc:0 "戦争を共に戦ったハットリバー公国を、オーストラリア連邦の自治地域として正式に承認する。レオナード1世の勇気は歴史に刻まれるだろう。"
+
+ AST_sew_reclaim_west:0 "西部大陸の再統合"
+ AST_sew_reclaim_west_desc:0 "長らくエミューの足下に踏み荒らされた西オーストラリアを、ついにオーストラリア連邦の版図に取り戻す。"
+
+ AST_sew_gbr_thank_you:0 "英国への感謝外交"
+ AST_sew_gbr_thank_you_desc:0 "戦争中に支援してくれたイギリスに正式な感謝の意を表す。コモンウェルスの絆は、エミューの爪でも断ち切れなかった。"
+
+ ###########
+ # イベント: sew_support系
+ ###########
+ sew_support.1.t:0 "ASTへ支援を要請せよ"
+ sew_support.1.d:0 "西海岸の一角を確保したが、エミュー帝国の圧力はまだ続いている。タスマニアに逃れたオーストラリア連邦に支援を求めるべきか？レオナード1世は決断を迫られている。"
+ sew_support.1.a:0 "オーストラリア連邦に支援を要請する"
+ sew_support.1.b:0 "我らの力だけで戦い続ける"
+
+ sew_support.2.t:0 "ハットリバーからの支援要請"
+ sew_support.2.d:0 "ハットリバー公国のレオナード1世から緊急の支援要請が届いた。彼らは西海岸を守り続けているが、エミュー帝国の圧力の前に限界が近づきつつある。我々は何をすべきか？"
+ sew_support.2.a:0 "武器・物資を送る"
+ sew_support.2.b:0 "軍事顧問団を派遣する"
+ sew_support.2.c:0 "正規軍を派遣し、共に戦う"
+ sew_support.2.d:0 "今は動けない"
+
+ sew_support.3.t:0 "オーストラリア連邦の拒否"
+ sew_support.3.d:0 "オーストラリア連邦からの返答は「ノー」だった。タスマニアの安全を優先し、本土への介入は時期尚早と判断したようだ。我らは孤立無援のまま戦い続けなければならない。"
+ sew_support.3.a:0 "…なら、一人でやってやる"
+
+ sew_support.4.t:0 "前線への物資到着報告"
+ sew_support.4.d:0 "オーストラリア連邦から送られた武器・弾薬が最前線に届いた！民兵たちの士気が一気に上がった。エミューを撃ち返す銃があれば、話は変わってくる。追加の支援もお願いしたいところだが…"
+ sew_support.4.a:0 "感謝の報告を送り、追加支援を要請する"
+
+ sew_support.5.t:0 "参戦の決断"
+ sew_support.5.d:0 "ハットリバーの奮闘と物資支援だけでは状況を変えるには不十分だ。エミュー帝国を本当に打倒するには、オーストラリア連邦が正面から立ち向かうしかない。宣戦布告の準備は整っているか？"
+ sew_support.5.a:0 "今すぐ宣戦する！"
+ sew_support.5.b:0 "もう少し準備を整えてから"
+
+ sew_support.6.t:0 "ハットリバーからの追加支援要請"
+ sew_support.6.d:0 "ハットリバーから感謝の報告と共に、追加の砲兵装備と兵員補充の要請が届いた。彼らはまだ戦っている。我々はさらに支援できるか？"
+ sew_support.6.a:0 "砲兵装備と補充兵を送る"
+ sew_support.6.b:0 "今の支援で十分なはずだ"
+
+ sew_support.7.t:0 "オーストラリア連邦、参戦！"
+ sew_support.7.d:0 "ついにオーストラリア連邦が正式に参戦を宣言した！タスマニアから艦隊が出港し、正規軍がエミュー帝国に宣戦布告した。我々は孤独ではない！"
+ sew_support.7.a:0 "共に戦おう！大陸を取り戻せ！"
+
+ sew_support.8.t:0 "英国参観武官の到着"
+ sew_support.8.d:0 "ロンドンから参観武官が到着した。イギリスはこの戦争を「コモンウェルスの危機」と見なしており、状況を注視しているようだ。我々はイギリスの関与を求めるべきか？"
+ sew_support.8.a:0 "英国の支援を歓迎する"
+ sew_support.8.b:0 "コモンウェルスの問題は自分たちで解決する"
+
+ ###########
+ # イベント: sew_aus系
+ ###########
+ sew_aus.1.t:0 "オーストラリア連邦が宣戦！"
+ sew_aus.1.d:0 "あの逃げ腰のタスマニア政府がついに牙を剥いた！オーストラリア連邦が我がエミュー帝国に宣戦布告した。それがどうした、我らが最強のエミュー軍に正面から挑むとはいい度胸だ。"
+ sew_aus.1.a:0 "全エミュー戦士よ！タスマニアの蛙どもを踏み潰せ！"
+ sew_aus.1.b:0 "…戦略的に後退しつつ準備を整える"
+
+ ###########
+ # イベント: sew_gbr系
+ ###########
+ sew_gbr.1.t:0 "オーストラリア情勢報告"
+ sew_gbr.1.d:0 "オーストラリアの現地武官から報告が届いた。エミュー帝国がコモンウェルスの自治領を脅かしており、ハットリバーとオーストラリア連邦が苦戦を続けている。大英帝国はどう動くべきか？"
+ sew_gbr.1.a:0 "コモンウェルスの義務として支援を継続する"
+ sew_gbr.1.b:0 "現地の問題は現地で解決させる"
+
+ ###########
+ # 国家精神
+ ###########
+ AST_sew_war_mobilization:0 "対エミュー総動員令"
+ AST_sew_war_mobilization_desc:0 "エミュー帝国との全面戦争に向けて、国家の全リソースを戦争目的に集中している。"
+
+ AST_sew_war_preparation:0 "参戦準備"
+ AST_sew_war_preparation_desc:0 "軍の訓練と装備の整備を急ぎ、参戦に向けた最終準備を進めている。"
+
+ AST_sew_british_liaison:0 "英国連絡将校団"
+ AST_sew_british_liaison_desc:0 "イギリス軍から派遣された連絡将校たちが、情報共有と作戦調整を担っている。"
+
+ AST_sew_british_support_active:0 "英国の積極支援"
+ AST_sew_british_support_active_desc:0 "大英帝国がコモンウェルスの義務として積極的な軍事支援を提供している。"
+
+ AST_sew_independence_spirit:0 "独立不羈の精神"
+ AST_sew_independence_spirit_desc:0 "英国に頼らず、自力でこの戦争を解決するという強い意志が国民の士気を高めている。"
+
+ AST_sew_western_coast_supply_route:0 "西海岸補給路"
+ AST_sew_western_coast_supply_route_desc:0 "海路を通じてハットリバーへの安定した物資補給ルートが確立されている。"
+
+ AST_sew_west_reclaimed:0 "西部奪還の達成"
+ AST_sew_west_reclaimed_desc:0 "エミュー帝国に奪われた西オーストラリアの地を取り戻した。長い戦いの報いだ。"
+
+ HRH_sew_ast_equipped:0 "AST供給物資"
+ HRH_sew_ast_equipped_desc:0 "オーストラリア連邦から届いた武器と弾薬が、ハットリバー軍の戦力を大幅に向上させた。"
+
+ HRH_sew_ast_advisors:0 "AST軍事顧問団"
+ HRH_sew_ast_advisors_desc:0 "オーストラリア連邦の将校たちがハットリバー軍を指導している。農家の民兵が本物の兵士に変わりつつある。"
+
+ HRH_sew_ast_full_support:0 "AST全面支援"
+ HRH_sew_ast_full_support_desc:0 "オーストラリア連邦が全面的な軍事支援を約束した。我らは孤独ではない！"
+
+ HRH_sew_combined_ops_bonus:0 "合同作戦の優位"
+ HRH_sew_combined_ops_bonus_desc:0 "ASTとHRHの緊密な連携が、エミュー帝国に対して戦術的優位をもたらしている。"
+
+ HRH_sew_alone_spirit:0 "孤立した抵抗"
+ HRH_sew_alone_spirit_desc:0 "誰も助けに来ないなら、自分たちで戦うまでだ。ハットリバーの民は決して諦めない。"
+
+ HRH_sew_ast_recognition:0 "ASTによる承認"
+ HRH_sew_ast_recognition_desc:0 "オーストラリア連邦がハットリバー公国を正式な自治地域として承認した。レオナード1世の遺志は報われた。"
+
+ AUS_sew_war_footing:0 "第二次大戦体制"
+ AUS_sew_war_footing_desc:0 "人間どもが再び牙を剥いた！エミュー帝国は全兵力を動員し、これを打ち砕く。"
+
+ AUS_sew_defensive_posture:0 "戦略的防衛態勢"
+ AUS_sew_defensive_posture_desc:0 "全面衝突は得策ではない。陣地を固め、敵の補給線を断ち、じっくりと勝機を待つ。"
+
+ GBR_sew_commonwealth_duty:0 "コモンウェルスの義務"
+ GBR_sew_commonwealth_duty_desc:0 "オーストラリアの問題に介入することはコストがかかるが、コモンウェルスの絆を守ることは大英帝国の義務である。"


### PR DESCRIPTION
## 概要

ハットリバー公国(HRH)が**本土抵抗勢力**として西オーストラリア(州884)に進出し、タスマニア拠点のオーストラリア連邦(AST)が支援→参戦する「第二次エミュー戦争」コンテンツの全実装。

## 実装内容

### イベント・フォーカスツリー・国家精神・ローカライゼーション (コミット: f66a895b)
- **`bakasekai/events/second_emu_war_ast_support_events.txt`**
  - Namespace: `sew_support` (8件) / `sew_aus` (1件) / `sew_gbr` (1件) = 計10イベント
  - HRH→ASTの支援要請チェーン（装備支援/顧問派遣/参戦確認/拒否の4択）
- **`bakasekai/common/national_focus/AST_second_emu_war.txt`**
  - `focus_tree id = ast_second_emu_war_focus`、13フォーカス
  - 3ブランチ構造（物資左 / 顧問中央 / 英国右）→ 動員 → 参戦 → 戦後
- **`bakasekai/common/ideas/second_emu_war_ideas.txt`**
  - 16国家精神（AST×7 / HRH×6 / AUS×2 / GBR×1）
- **`bakasekai/localisation/japanese/bakasekai/second_emu_war_l_japanese.yml`**
  - 全コンテンツの日本語テキスト

### AI 兵科・編制実装 (コミット: a311d160)
- **`bakasekai/common/ai_templates/sew_templates.txt`**
  - HRH: irregular_core→reinforced→regular_combined の3段階アップグレード
  - AST: standard→assault歩兵 + marines（参戦後優先度×4）
  - AUS: emu_standard→emu_wartime（war_footing連動）
- **`bakasekai/common/ai_strategy/sew_strategies.txt`**
  - HRH(6) / AST(8) / AUS(5) = 計19ストラテジー
  - 兵力比率・研究優先度・外交・生産・エリア優先を網羅
- **`bakasekai/common/ai_strategy_plans/sew_strategy_plans.txt`**
  - `HRH_sew_resistance_plan`: focus_1→8の抵抗フォーカス順、infantry_weapons=50
  - `AST_sew_intervention_plan`: Bokka_Alliance参加後の積極介入（naval_equipment=45）
  - `AST_sew_defense_plan`: 消極支援路線（mobilize/declare_warのfocus_factors=0.0）

### ドキュメント更新 (コミット: 371de501)
- **`CONTENT_PLAN_second_emu_war.md`** 全面改訂
  - HRH「亡命政権」→「本土抵抗勢力」の正確な位置づけに修正
  - 実装ファイル・ゲームフロー・AI設計を全て実態に合わせて更新

## 既存コンテンツとの接続

```
HRH_recapture_states.2 (既存) → create_faction Bokka_Alliance
                                → ★ sew_support.1 を HRH に送信（新コンテンツ起動）
```

## テスト状況
- HOI4ゲーム内検証: 未実施（MODのためコマンドラインビルド不可）
- スクリプト構文: 手動確認済み（HRH_TECH_2でmilita/irregular解放を前提とするテンプレートを使用）

## 関連 State IDs
- 1097: ハットリバー本拠地（HRH所有）
- 884: 西オーストラリア（AUS所有→HRHが奪取対象）
- 518: タスマニア（AST首都）