### PR TITLE
EA: 初期陣営の固有「陣営精神」マーカーを self-heal

### DIFF
--- a/bakasekai/common/on_actions/bsm_economic_alliance_on_actions.txt
+++ b/bakasekai/common/on_actions/bsm_economic_alliance_on_actions.txt
@@ -25,6 +25,8 @@ on_actions = {
 				set_temp_variable = { bsm_ea_token = var:v_token }
 				bsm_ea_vote_weekly_update = yes
 			}
+			# 初期4陣営の固有「陣営精神」マーカーを再付与 (self-heal)
+			XXX = { bsm_ea_reassert_membership_ideas = yes }
 		}
 	}
 

--- a/bakasekai/common/scripted_effects/bsm_ea_initialization.txt
+++ b/bakasekai/common/scripted_effects/bsm_ea_initialization.txt
@@ -38,6 +38,8 @@ bsm_ea_init_initial_factions = {
 				bsm_ea_generate_new_token = yes
 				bsm_ea_create_sphere = yes
 				add_ideas = bsm_ea_idea_european_union
+				# 安定した陣営トークンを保存 (盟主交代後も marker 修復が追従できるように)
+				set_variable = { global.bsm_ea_token_european_union = bsm_ea_sphere }
 
 				if = { limit = { OZY = { exists = yes } }
 					OZY = {
@@ -82,6 +84,8 @@ bsm_ea_init_initial_factions = {
 				bsm_ea_generate_new_token = yes
 				bsm_ea_create_sphere = yes
 				add_ideas = bsm_ea_idea_commonwealth
+				# 安定した陣営トークンを保存 (盟主交代後も marker 修復が追従できるように)
+				set_variable = { global.bsm_ea_token_commonwealth = bsm_ea_sphere }
 
 				if = { limit = { CAN = { exists = yes } } CAN = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_commonwealth } }
 				if = { limit = { AST = { exists = yes } } AST = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_commonwealth } }
@@ -111,6 +115,8 @@ bsm_ea_init_initial_factions = {
 				bsm_ea_generate_new_token = yes
 				bsm_ea_create_sphere = yes
 				add_ideas = bsm_ea_idea_east_asia_league
+				# 安定した陣営トークンを保存 (盟主交代後も marker 修復が追従できるように)
+				set_variable = { global.bsm_ea_token_east_asia_league = bsm_ea_sphere }
 
 				if = { limit = { MAN = { exists = yes } } MAN = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_east_asia_league } }
 				if = { limit = { MEN = { exists = yes } } MEN = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_east_asia_league } }
@@ -131,6 +137,8 @@ bsm_ea_init_initial_factions = {
 				bsm_ea_generate_new_token = yes
 				bsm_ea_create_sphere = yes
 				add_ideas = bsm_ea_idea_iberian_union
+				# 安定した陣営トークンを保存 (盟主交代後も marker 修復が追従できるように)
+				set_variable = { global.bsm_ea_token_iberian_union = bsm_ea_sphere }
 
 				if = { limit = { CEU = { exists = yes } } CEU = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_iberian_union } }
 				if = { limit = { PML = { exists = yes } } PML = { bsm_ea_init_add_member = yes add_ideas = bsm_ea_idea_iberian_union } }

--- a/bakasekai/common/scripted_effects/bsm_ea_system_effects.txt
+++ b/bakasekai/common/scripted_effects/bsm_ea_system_effects.txt
@@ -169,58 +169,72 @@ bsm_ea_join_sphere = {
 # これらのアイデアは GetEAName で陣営名を表示するための表示用マーカーで、
 # どこでも remove されない想定だが、外れている場合に現メンバーへ再付与する。
 # on_weekly / on_monthly から XXX スコープで呼ぶ。
-# 現在その陣営に所属している国にしか付与しないため誤付与しない。
+#
+# 重要: 陣営の識別は初期化時に保存した「安定トークン」(global.bsm_ea_token_*)
+# で行う。盟主タグ(JPN等)の bsm_ea_sphere は離脱/盟主交代で書き換わるため、
+# それを辿ると (1) 盟主交代後の陣営を healing できず、(2) 盟主が別の陣営へ
+# 移った場合に無関係なメンバーへ marker を誤付与してしまう。トークンは sphere_list
+# /member_list のキーとして盟主交代後も不変なので、これを使う。
+# 陣営が解散済み(token が sphere_list に無い)場合は何もしない。
 # ------------------------------------------
 bsm_ea_reassert_membership_ideas = {
 	# 欧州連合 (EUR)
 	if = {
-		limit = { EUR = { exists = yes has_variable = bsm_ea_sphere } }
-		set_temp_variable = { t_reassert_token = 0 }
-		EUR = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
-		for_each_loop = {
-			array = global.bsm_ea_member_list_@var:t_reassert_token
-			value = v_reassert_mem
-			var:v_reassert_mem = {
-				if = { limit = { NOT = { has_idea = bsm_ea_idea_european_union } } add_ideas = bsm_ea_idea_european_union }
+		limit = { has_variable = global.bsm_ea_token_european_union }
+		set_temp_variable = { t_reassert_token = global.bsm_ea_token_european_union }
+		if = {
+			limit = { is_in_array = { global.bsm_ea_sphere_list = var:t_reassert_token } }
+			for_each_loop = {
+				array = global.bsm_ea_member_list_@var:t_reassert_token
+				value = v_reassert_mem
+				var:v_reassert_mem = {
+					if = { limit = { NOT = { has_idea = bsm_ea_idea_european_union } } add_ideas = bsm_ea_idea_european_union }
+				}
 			}
 		}
 	}
 	# コモンウェルス (GBR)
 	if = {
-		limit = { GBR = { exists = yes has_variable = bsm_ea_sphere } }
-		set_temp_variable = { t_reassert_token = 0 }
-		GBR = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
-		for_each_loop = {
-			array = global.bsm_ea_member_list_@var:t_reassert_token
-			value = v_reassert_mem
-			var:v_reassert_mem = {
-				if = { limit = { NOT = { has_idea = bsm_ea_idea_commonwealth } } add_ideas = bsm_ea_idea_commonwealth }
+		limit = { has_variable = global.bsm_ea_token_commonwealth }
+		set_temp_variable = { t_reassert_token = global.bsm_ea_token_commonwealth }
+		if = {
+			limit = { is_in_array = { global.bsm_ea_sphere_list = var:t_reassert_token } }
+			for_each_loop = {
+				array = global.bsm_ea_member_list_@var:t_reassert_token
+				value = v_reassert_mem
+				var:v_reassert_mem = {
+					if = { limit = { NOT = { has_idea = bsm_ea_idea_commonwealth } } add_ideas = bsm_ea_idea_commonwealth }
+				}
 			}
 		}
 	}
 	# 東亜連盟 (JPN)
 	if = {
-		limit = { JPN = { exists = yes has_variable = bsm_ea_sphere } }
-		set_temp_variable = { t_reassert_token = 0 }
-		JPN = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
-		for_each_loop = {
-			array = global.bsm_ea_member_list_@var:t_reassert_token
-			value = v_reassert_mem
-			var:v_reassert_mem = {
-				if = { limit = { NOT = { has_idea = bsm_ea_idea_east_asia_league } } add_ideas = bsm_ea_idea_east_asia_league }
+		limit = { has_variable = global.bsm_ea_token_east_asia_league }
+		set_temp_variable = { t_reassert_token = global.bsm_ea_token_east_asia_league }
+		if = {
+			limit = { is_in_array = { global.bsm_ea_sphere_list = var:t_reassert_token } }
+			for_each_loop = {
+				array = global.bsm_ea_member_list_@var:t_reassert_token
+				value = v_reassert_mem
+				var:v_reassert_mem = {
+					if = { limit = { NOT = { has_idea = bsm_ea_idea_east_asia_league } } add_ideas = bsm_ea_idea_east_asia_league }
+				}
 			}
 		}
 	}
 	# イベリア経済連合 (ESP)
 	if = {
-		limit = { ESP = { exists = yes has_variable = bsm_ea_sphere } }
-		set_temp_variable = { t_reassert_token = 0 }
-		ESP = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
-		for_each_loop = {
-			array = global.bsm_ea_member_list_@var:t_reassert_token
-			value = v_reassert_mem
-			var:v_reassert_mem = {
-				if = { limit = { NOT = { has_idea = bsm_ea_idea_iberian_union } } add_ideas = bsm_ea_idea_iberian_union }
+		limit = { has_variable = global.bsm_ea_token_iberian_union }
+		set_temp_variable = { t_reassert_token = global.bsm_ea_token_iberian_union }
+		if = {
+			limit = { is_in_array = { global.bsm_ea_sphere_list = var:t_reassert_token } }
+			for_each_loop = {
+				array = global.bsm_ea_member_list_@var:t_reassert_token
+				value = v_reassert_mem
+				var:v_reassert_mem = {
+					if = { limit = { NOT = { has_idea = bsm_ea_idea_iberian_union } } add_ideas = bsm_ea_idea_iberian_union }
+				}
 			}
 		}
 	}

--- a/bakasekai/common/scripted_effects/bsm_ea_system_effects.txt
+++ b/bakasekai/common/scripted_effects/bsm_ea_system_effects.txt
@@ -164,6 +164,68 @@ bsm_ea_join_sphere = {
 	}
 }
 
+# ------------------------------------------
+# 初期4陣営の固有「陣営精神」マーカーを再付与 (self-heal)
+# これらのアイデアは GetEAName で陣営名を表示するための表示用マーカーで、
+# どこでも remove されない想定だが、外れている場合に現メンバーへ再付与する。
+# on_weekly / on_monthly から XXX スコープで呼ぶ。
+# 現在その陣営に所属している国にしか付与しないため誤付与しない。
+# ------------------------------------------
+bsm_ea_reassert_membership_ideas = {
+	# 欧州連合 (EUR)
+	if = {
+		limit = { EUR = { exists = yes has_variable = bsm_ea_sphere } }
+		set_temp_variable = { t_reassert_token = 0 }
+		EUR = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
+		for_each_loop = {
+			array = global.bsm_ea_member_list_@var:t_reassert_token
+			value = v_reassert_mem
+			var:v_reassert_mem = {
+				if = { limit = { NOT = { has_idea = bsm_ea_idea_european_union } } add_ideas = bsm_ea_idea_european_union }
+			}
+		}
+	}
+	# コモンウェルス (GBR)
+	if = {
+		limit = { GBR = { exists = yes has_variable = bsm_ea_sphere } }
+		set_temp_variable = { t_reassert_token = 0 }
+		GBR = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
+		for_each_loop = {
+			array = global.bsm_ea_member_list_@var:t_reassert_token
+			value = v_reassert_mem
+			var:v_reassert_mem = {
+				if = { limit = { NOT = { has_idea = bsm_ea_idea_commonwealth } } add_ideas = bsm_ea_idea_commonwealth }
+			}
+		}
+	}
+	# 東亜連盟 (JPN)
+	if = {
+		limit = { JPN = { exists = yes has_variable = bsm_ea_sphere } }
+		set_temp_variable = { t_reassert_token = 0 }
+		JPN = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
+		for_each_loop = {
+			array = global.bsm_ea_member_list_@var:t_reassert_token
+			value = v_reassert_mem
+			var:v_reassert_mem = {
+				if = { limit = { NOT = { has_idea = bsm_ea_idea_east_asia_league } } add_ideas = bsm_ea_idea_east_asia_league }
+			}
+		}
+	}
+	# イベリア経済連合 (ESP)
+	if = {
+		limit = { ESP = { exists = yes has_variable = bsm_ea_sphere } }
+		set_temp_variable = { t_reassert_token = 0 }
+		ESP = { set_temp_variable = { PREV.t_reassert_token = bsm_ea_sphere } }
+		for_each_loop = {
+			array = global.bsm_ea_member_list_@var:t_reassert_token
+			value = v_reassert_mem
+			var:v_reassert_mem = {
+				if = { limit = { NOT = { has_idea = bsm_ea_idea_iberian_union } } add_ideas = bsm_ea_idea_iberian_union }
+			}
+		}
+	}
+}
+
 # 現在の経済陣営から離脱
 # 入力:
 #   bsm_ea_token (一時変数) - 必須


### PR DESCRIPTION
## 概要 / Summary

JPN が開始直後に **東亜連盟 (`bsm_ea_idea_east_asia_league`)** を失う問題への対応です。

`bsm_ea_idea_*`（東亜連盟 / 欧州連合 / コモンウェルス / イベリア経済連合）は **modifier を持たない表示用マーカー**で、`GetEAName` が `has_idea` で陣営名を表示するために使います。付与は `bsm_ea_initialization.txt` の1か所のみです。

## 調査結果

EAシステム全体（初期化・加盟・脱退・解散・週次/月次更新・役職同期・on_startup×5・GUI/decision/diplo_action）を追跡しましたが、**これらのマーカーアイデアを `remove_ideas` するコードは mod 内に存在しません**。また `hidden_ideas` カテゴリは**スタックする**（`SOV_targeted_bonus_against_*` 等が同時保持される設計で実証）ため、別アイデアによるスロット押し出しも起きません。したがって開始直後に消える真因は静的解析では特定できませんでした（セーブ/エンジン挙動/外的要因の可能性）。

## 変更内容 / Changes

除去元が直せないため、最も安全・確実な **self-heal（再付与）** を実装:

- `bsm_ea_reassert_membership_ideas`（`bsm_ea_system_effects.txt`）を追加し、EA `on_weekly` から `XXX = { ... }` で呼び出し
- 初期4陣営それぞれについて、**そのメンバーにマーカーが無ければ再付与**

### 陣営の識別は「安定トークン」で行う（レビュー P2 対応）
当初は盟主タグの `bsm_ea_sphere` を辿っていましたが、これは離脱/盟主交代で書き換わるため、(1) 盟主交代後の陣営を healing できず、(2) その盟主が別/カスタム陣営へ移ると無関係なメンバーへマーカーを誤付与し `GetEAName` が誤名表示する問題がありました。

対応として、**初期化時に各陣営の token を不変なグローバルへ保存**し、repair はそれを使います:
- `global.bsm_ea_token_european_union / _commonwealth / _east_asia_league / _iberian_union`
- token は `sphere_list` / `member_list` のキーで**盟主交代後も不変** → 正しい陣営を追従、無関係な陣営へは触れない
- ガード: グローバル未設定（旧セーブ）はスキップ / token が `sphere_list` に無い（解散済み）はスキップ

### 安全性
- そのトークンの陣営に所属しているメンバーにしか付与しない → **誤付与しない**
- 既にあれば何もしない → **idempotent**
- 「prepared」マーカー（GEACPS 等）は未付与＝陣営 identity の変化が無いことも確認済み

検証: `search_defs.py --check` 通過。

## 留意点
対症療法のため、「開始数日で必ず消える」場合は週次回復までの数日は表示名が欠ける可能性があります。真因特定が必要なら付与直後＋各 on_action に `log` を仕込んで「いつ `has_idea` が false になるか」を追跡できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)