### PR TITLE
支援中隊「酒保中隊」を追加 (ツリー外技術)

### DIFF
--- a/bakasekai/common/technologies/_bsm_sutler_company_tech.txt
+++ b/bakasekai/common/technologies/_bsm_sutler_company_tech.txt
@@ -1,0 +1,39 @@
+technologies = {
+	# BSM ネタ支援中隊「酒保中隊」を解禁する研究
+	# 同時に底割ったビール瓶も生産可能にする (酒保が前線へ配給する)
+	tech_bsm_sutler_company = {
+		enable_subunits = {
+			bsm_sutler_company
+		}
+		enable_equipments = {
+			bsm_broken_beer_bottle_equipment
+		}
+		research_cost = 1.25
+		start_year = 1936
+		folder = {
+			name = support_folder
+			position = {
+				x = 8
+				y = 2
+			}
+		}
+		categories = {
+			support_tech
+		}
+		ai_will_do = {
+			base = 1
+			modifier = {
+				factor = 1.2
+				date > "1937.1.1"
+			}
+			modifier = {
+				factor = 1.2
+				date > "1938.1.1"
+			}
+			modifier = {
+				factor = 1.2
+				date > "1939.1.1"
+			}
+		}
+	}
+}

--- a/bakasekai/common/technologies/_bsm_sutler_company_tech.txt
+++ b/bakasekai/common/technologies/_bsm_sutler_company_tech.txt
@@ -1,39 +1,18 @@
 technologies = {
-	# BSM ネタ支援中隊「酒保中隊」を解禁する研究
-	# 同時に底割ったビール瓶も生産可能にする (酒保が前線へ配給する)
+	# BSM ネタ支援中隊「酒保中隊」を解禁する研究 (ツリー外)
+	# allow = always no のためフォーカス/イベント等で add_tech により付与する
+	# 解禁と同時に底割ったビール瓶も生産可能にする (酒保が前線へ配給する)
 	tech_bsm_sutler_company = {
+		allow = {
+			always = no
+		}
 		enable_subunits = {
 			bsm_sutler_company
 		}
 		enable_equipments = {
 			bsm_broken_beer_bottle_equipment
 		}
-		research_cost = 1.25
+		research_cost = 1
 		start_year = 1936
-		folder = {
-			name = support_folder
-			position = {
-				x = 8
-				y = 2
-			}
-		}
-		categories = {
-			support_tech
-		}
-		ai_will_do = {
-			base = 1
-			modifier = {
-				factor = 1.2
-				date > "1937.1.1"
-			}
-			modifier = {
-				factor = 1.2
-				date > "1938.1.1"
-			}
-			modifier = {
-				factor = 1.2
-				date > "1939.1.1"
-			}
-		}
 	}
 }

--- a/bakasekai/common/technologies/support.txt
+++ b/bakasekai/common/technologies/support.txt
@@ -45,10 +45,6 @@ technologies = {
 			leads_to_tech = tech_maintenance_company
 			research_cost_coeff = 1
 		}
-		path = {
-			leads_to_tech = tech_bsm_sutler_company
-			research_cost_coeff = 1
-		}
 		research_cost = 1
 		start_year = 1918
 		folder = {

--- a/bakasekai/common/technologies/support.txt
+++ b/bakasekai/common/technologies/support.txt
@@ -45,6 +45,10 @@ technologies = {
 			leads_to_tech = tech_maintenance_company
 			research_cost_coeff = 1
 		}
+		path = {
+			leads_to_tech = tech_bsm_sutler_company
+			research_cost_coeff = 1
+		}
 		research_cost = 1
 		start_year = 1918
 		folder = {

--- a/bakasekai/common/units/bsm_sutler_company.txt
+++ b/bakasekai/common/units/bsm_sutler_company.txt
@@ -1,0 +1,66 @@
+sub_units = {
+	# BSM ネタ支援中隊: 酒保中隊 (Sutler / Canteen Company)
+	# 底割ったビール瓶を配って前線の士気を回復させる、バカ地図らしい支援中隊
+	bsm_sutler_company = {
+		abbreviation = "SAK"
+		sprite = infantry
+		map_icon_category = infantry
+		priority = 0
+		ai_priority = 0
+		active = no
+		affects_speed = no
+
+		type = {
+			infantry
+			support
+		}
+
+		group = support
+
+		categories = {
+			category_support_battalions
+			category_divisional_support_battalions
+			category_army
+		}
+
+		regimental = no
+		combat_width = 0
+
+		#Size Definitions
+		max_strength = 2
+		max_organisation = 20
+		default_morale = 0.3
+		manpower = 500
+		training_time = 120
+
+		#Misc Abilities
+		weight = 0.1
+		supply_consumption = 0.04
+		can_be_parachuted = yes
+
+		# Important Ability
+		casualty_trickleback = 0.10
+		experience_loss_factor = -0.10
+
+		own_equipment_fuel_consumption_mult = 0.0 # no fuel use
+
+		battalion_mult = {
+			category = category_all_infantry
+			default_morale = 0.05
+		}
+
+		essential = {
+			support_equipment
+			motorized_equipment
+		}
+
+		# ビールが無いと士気は上がらない: 底割ったビール瓶を要求する
+		need = {
+			support_equipment = 20
+			bsm_broken_beer_bottle_equipment = 10
+			motorized_equipment = 10
+		}
+
+		same_support_type = bsm_sutler_company
+	}
+}

--- a/bakasekai/interface/_bsm_sutler_company.gfx
+++ b/bakasekai/interface/_bsm_sutler_company.gfx
@@ -1,0 +1,7 @@
+spriteTypes = {
+	# 酒保中隊テクノロジのツリーアイコン (暫定: ネタ飲料アイコンを流用)
+	SpriteType = {
+		name = "GFX_tech_bsm_sutler_company_medium"
+		texturefile = "gfx/interface/technologies/inf_tech/pepsi.png"
+	}
+}

--- a/bakasekai/localisation/japanese/_bsm_sutler_company_l_japanese.yml
+++ b/bakasekai/localisation/japanese/_bsm_sutler_company_l_japanese.yml
@@ -1,0 +1,5 @@
+l_japanese:
+ tech_bsm_sutler_company:0 "酒保中隊"
+ tech_bsm_sutler_company_desc:0 "前線に酒保（さかば）を開く。底割ったビール瓶を担いだ酒保兵が塹壕を巡回し、将兵の士気を回復させる。なお武器の支給も兼ねる。"
+ bsm_sutler_company:0 "酒保中隊"
+ bsm_sutler_company_desc:0 "前線で酒と物資を配給する酒保中隊。師団全体の士気を底上げし、損耗兵の復帰（補充）を早める。ただしビールの在庫が切れると本気を出さない。"


### PR DESCRIPTION
## 概要

バカ地図らしいネタ支援中隊 **「酒保中隊」(Sutler / Canteen Company)** を追加します。既存の `bsm_broken_beer_bottle`（底割ったビール瓶）ネタと連動し、前線でビール瓶を配給して士気と補充を回復させる支援中隊です。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `bakasekai/common/units/bsm_sutler_company.txt` | 支援中隊 sub_unit 定義 |
| `bakasekai/common/technologies/_bsm_sutler_company_tech.txt` | 解禁テクノロジ（**ツリー外** / `allow = always no`） |
| `bakasekai/interface/_bsm_sutler_company.gfx` | テックツリーアイコン（暫定流用） |
| `bakasekai/localisation/japanese/_bsm_sutler_company_l_japanese.yml` | 日本語ローカライズ |

## 仕様

- **効果**: 師団全体の士気 +5%（`battalion_mult` on `category_all_infantry`）、`casualty_trickleback = 0.10`、`experience_loss_factor = -0.10`
- **ネタ要素**: `need` に `bsm_broken_beer_bottle_equipment` を要求 ＝「ビールが切れると本気を出さない」
- **解禁**: ツリー外技術のため、フォーカス/イベント/ディシジョンから `add_tech = { tech_bsm_sutler_company = 1 }` で付与。研究で底割ったビール瓶の生産も解禁。

## 確認事項 / TODO

- ⚠️ アイコンは暫定で `pepsi.png`（既存のネタ飲料画像）を流用。専用のビール瓶アイコンに差し替え推奨。
- ⚠️ 付与トリガー（どのフォーカス/イベントで解禁するか）は未実装。
- ⚠️ ゲーム内検証（mod起動・師団デザイナー表示確認・バランス）は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaFeU369NAbtTPR8J1WRr9)_